### PR TITLE
[DON'T MERGE] Minimal broken rendering example

### DIFF
--- a/examples/broken/package.json
+++ b/examples/broken/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "@prodo-example/broken",
+  "version": "1.0.0",
+  "license": "MIT",
+  "private": true,
+  "scripts": {
+    "clean": "rm -rf .cache build dist lib tsconfig.tsbuildinfo",
+    "start": "parcel src/index.html",
+    "test": "jest",
+    "lint": "set -ex; tsc --build; tslint --project ."
+  },
+  "dependencies": {
+    "@prodo/core": "1.0.0",
+    "@prodo/effect-plugin": "1.0.0",
+    "react": "^16.8.6",
+    "react-dom": "^16.9.0"
+  },
+  "devDependencies": {
+    "@testing-library/react": "^9.1.3",
+    "@types/jest": "^24.0.18",
+    "@types/node": "^12.7.2",
+    "@types/react": "^16.8.25",
+    "@types/react-dom": "^16.8.5",
+    "@types/testing-library__react": "^9.1.1",
+    "jest": "^24.9.0",
+    "parcel-bundler": "^1.12.3",
+    "sass": "^1.22.9",
+    "ts-jest": "^24.0.2"
+  },
+  "jest": {
+    "transform": {
+      "^.+\\.tsx?$": "ts-jest"
+    }
+  }
+}

--- a/examples/broken/src/App.tsx
+++ b/examples/broken/src/App.tsx
@@ -1,0 +1,32 @@
+import * as React from "react";
+import { model } from "./model";
+
+const Cell = model.connect(({ state, watch }) => (props: { name: string }) => {
+  const item = watch(state.grid[props.name]);
+  const bg = item === undefined ? "white" : item === false ? "red" : "green";
+  return <div style={{ backgroundColor: bg }}>{props.name}</div>;
+});
+
+const run = model.action(({ state }) => (values: string[]) => {
+  values.forEach(name => {
+    state.grid[name] = name[0] === name[0].toUpperCase();
+  });
+});
+
+const RunButton = model.connect(
+  ({ dispatch }) => (props: { names: string[] }) => (
+    <button onClick={() => dispatch(run)(props.names)}>Run</button>
+  ),
+);
+
+const names = ["a", "A", "b", "B"];
+const App = () => (
+  <div className="app">
+    {names.map(name => (
+      <Cell key={name} name={name} />
+    ))}
+    <RunButton names={names} />
+  </div>
+);
+
+export default App;

--- a/examples/broken/src/index.html
+++ b/examples/broken/src/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="X-UA-Compatible" content="ie=edge" />
+    <title>V2 Example</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script src="./index.tsx"></script>
+  </body>
+</html>

--- a/examples/broken/src/index.scss
+++ b/examples/broken/src/index.scss
@@ -1,0 +1,16 @@
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  padding: 0;
+  color: #333;
+
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
+    Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif,
+    "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
+
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}

--- a/examples/broken/src/index.tsx
+++ b/examples/broken/src/index.tsx
@@ -1,0 +1,16 @@
+import { ProdoProvider } from "@prodo/core";
+import * as React from "react";
+import * as ReactDOM from "react-dom";
+import App from "./App";
+import { model } from "./model";
+import { initState } from "./store";
+
+import "./index.scss";
+
+const store = model.createStore({ initState });
+ReactDOM.render(
+  <ProdoProvider value={store}>
+    <App />
+  </ProdoProvider>,
+  document.getElementById("root"),
+);

--- a/examples/broken/src/model.ts
+++ b/examples/broken/src/model.ts
@@ -1,0 +1,8 @@
+import { createModel } from "@prodo/core";
+import effectPlugin from "@prodo/effect-plugin";
+
+export interface State {
+  grid: { [key: string]: boolean };
+}
+
+export const model = createModel<State>().with(effectPlugin);

--- a/examples/broken/src/store.ts
+++ b/examples/broken/src/store.ts
@@ -1,0 +1,3 @@
+import { State } from "./model";
+
+export const initState: State = { grid: {} };

--- a/examples/broken/tsconfig.json
+++ b/examples/broken/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../tsconfig.ui.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "lib"
+  },
+  "include": ["src"],
+  "references": [
+    { "path": "../../packages/core" },
+    { "path": "../../packages/effect-plugin" }
+  ]
+}

--- a/packages/core/src/events.ts
+++ b/packages/core/src/events.ts
@@ -67,7 +67,7 @@ export const completeEvent = (event: Event, store: Store<any, any>): void => {
   submitPatches(store, store.universe, event.patches);
 
   event.nextActions.map(({ func, args, origin }) =>
-    store.exec(origin, func, args),
+    store.exec(origin, func, ...args),
   );
 
   if (store.watchForComplete) {

--- a/packages/core/src/store.ts
+++ b/packages/core/src/store.ts
@@ -57,7 +57,9 @@ export const createStore = <State>(
         const ctx = {
           state: u.state,
           stream,
-          dispatch: <A>(func: (a: A) => void) => (args: A) => {
+          dispatch: <A extends any[]>(func: (...a: A) => void) => (
+            ...args: A
+          ) => {
             event.nextActions.push({
               func,
               args,

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -129,7 +129,7 @@ export interface Event {
 }
 
 interface NextAction {
-  func: (c: any) => void;
+  func: (...c: any[]) => void;
   args: any;
   origin: Origin;
 }


### PR DESCRIPTION
A minimal example to show how rendering is broken on master, that is fixed in #13.

On `master`:

The individual items are subscribed to `state.grid[name]` which is set to `undefined` in the initial tree. This means that the `add` operation generated by the action does not trigger an update.

![Sep-04-2019 16-30-01](https://user-images.githubusercontent.com/5788205/64269200-68cb1e80-cf31-11e9-8f13-544b064754ac.gif)

On `fix-rendering`:

![Sep-04-2019 16-29-56](https://user-images.githubusercontent.com/5788205/64269214-6ec0ff80-cf31-11e9-84ae-39b8de874b9c.gif)


Note that all the changes to _packages/core_ are to cherry-pick an unrelated bug regarding actions with multiple arguments.