### PR TITLE
Improve babel plugin

### DIFF
--- a/examples/transpilation/src/App.tsx
+++ b/examples/transpilation/src/App.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import { initialize } from "./actions";
-import { dispatch, state, watch } from "./model";
+import { dispatch, state, watch } from "./model.ctx";
 
 export const App = () => {
   React.useEffect(() => {

--- a/examples/transpilation/src/actions.ts
+++ b/examples/transpilation/src/actions.ts
@@ -1,4 +1,4 @@
-import { state } from "./model";
+import { state } from "./model.ctx";
 
 export const initialize = () => {
   state.initialized = true;

--- a/examples/transpilation/src/model.ctx.ts
+++ b/examples/transpilation/src/model.ctx.ts
@@ -1,0 +1,3 @@
+import { model } from "./model";
+
+export const { dispatch, state, watch } = model.ctx;

--- a/examples/transpilation/src/model.ts
+++ b/examples/transpilation/src/model.ts
@@ -10,4 +10,3 @@ export const initState: State = {
 
 export const model = createModel<State>();
 export const { action, connect } = model;
-export const { dispatch, state, watch } = model.ctx;

--- a/packages/babel-plugin/src/inject-universe.ts
+++ b/packages/babel-plugin/src/inject-universe.ts
@@ -1,18 +1,9 @@
 import * as Babel from "@babel/core";
 import * as nodePath from "path";
-import { isInUniverse } from "./utils";
 
-type Context =
-  | {
-      importType: "specifiers";
-      importDeclarationPath: Babel.NodePath<Babel.types.ImportDeclaration>;
-      universe: Babel.types.ObjectPattern;
-    }
-  | {
-      importType: "namespace";
-      importDeclarationPath: Babel.NodePath<Babel.types.ImportDeclaration>;
-      universe: Babel.types.Identifier;
-    };
+const isModelContextImport = (importPath: string): boolean =>
+  importPath.startsWith(".") &&
+  /^model\.ctx(\.(j|t)sx?)?$/.test(nodePath.basename(importPath));
 
 export default (
   t: typeof Babel.types,
@@ -30,7 +21,15 @@ export default (
   bodyPath: Babel.NodePath<Babel.types.BlockStatement | Babel.types.Expression>,
   async?: boolean,
 ) => {
-  let context: Context | null = null;
+  const universeImports: {
+    namespace?: string;
+    specifiers: { [key: string]: string };
+    specifierRest?: string;
+    programPath?: Babel.NodePath<Babel.types.Program>;
+    modelSource?: string;
+  } = {
+    specifiers: {},
+  };
 
   bodyPath.traverse({
     Identifier(p: Babel.NodePath<Babel.types.Identifier>) {
@@ -38,77 +37,76 @@ export default (
       if (p.isReferencedIdentifier()) {
         const binding = p.scope.getBinding(p.node.name);
         if (binding != null) {
-          const importPath = binding.path;
-          if (
-            t.isImportSpecifier(importPath.node) &&
-            isInUniverse(importPath.node.imported.name)
-          ) {
-            const importDeclarationPath = importPath.parentPath;
-            if (t.isImportDeclaration(importDeclarationPath.node)) {
-              const source = importDeclarationPath.node.source;
-              if (
-                source.value.startsWith(".") &&
-                /^model(\.(j|t)s)?$/.test(nodePath.basename(source.value))
-              ) {
-                const importSpecifiers = importDeclarationPath.node.specifiers.filter(
-                  specifier => t.isImportSpecifier(specifier),
-                ) as Babel.types.ImportSpecifier[];
+          const bindingPath = binding.path;
 
-                context = {
-                  importType: "specifiers",
-                  importDeclarationPath: importDeclarationPath as Babel.NodePath<
-                    Babel.types.ImportDeclaration
-                  >,
-                  universe: t.objectPattern(
-                    importSpecifiers
-                      .filter((specifier: Babel.types.ImportSpecifier) =>
-                        isInUniverse(specifier.imported.name),
-                      )
-                      .map((specifier: Babel.types.ImportSpecifier) =>
-                        t.objectProperty(
-                          specifier.imported,
-                          specifier.local,
-                          false,
-                          specifier.imported.name === specifier.local.name,
-                        ),
-                      ),
-                  ),
-                };
-                p.stop();
-              }
+          if (
+            (t.isImportSpecifier(bindingPath.node) ||
+              t.isImportNamespaceSpecifier(bindingPath.node) ||
+              t.isImportDefaultSpecifier(bindingPath.node)) &&
+            t.isImportDeclaration(bindingPath.parent) &&
+            isModelContextImport(bindingPath.parent.source.value)
+          ) {
+            universeImports.modelSource = bindingPath.parent.source.value.replace(
+              /\.ctx(?=\.(j|t)sx?)?$/,
+              "",
+            );
+            universeImports.programPath = bindingPath.parentPath
+              .parentPath as Babel.NodePath<Babel.types.Program>;
+            if (t.isImportSpecifier(bindingPath.node)) {
+              // import {foo} from "./model.ctx";
+              universeImports.specifiers[bindingPath.node.imported.name] =
+                bindingPath.node.local.name;
+            } else if (t.isImportNamespaceSpecifier(bindingPath.node)) {
+              // import * as foo from "./model.ctx";
+              universeImports.namespace = bindingPath.node.local.name;
+            } else if (t.isImportDefaultSpecifier(bindingPath.node)) {
+              // import foo from "./model.ctx";
+              universeImports.specifiers.default = bindingPath.node.local.name;
             }
-          }
-        }
-      }
-    },
-    MemberExpression(p: Babel.NodePath<Babel.types.MemberExpression>) {
-      // Does it use `prodo.state` from `import * as prodo from "./model";`
-      if (!p.node.computed && isInUniverse(p.node.property.name)) {
-        const objectPath = p.get("object");
-        if (
-          t.isIdentifier(objectPath.node) &&
-          objectPath.isReferencedIdentifier()
-        ) {
-          const binding = objectPath.scope.getBinding(objectPath.node.name);
-          if (binding != null) {
-            const importPath = binding.path;
-            if (t.isImportNamespaceSpecifier(importPath.node)) {
-              const importDeclarationPath = importPath.parentPath;
-              if (t.isImportDeclaration(importDeclarationPath.node)) {
-                const source = importDeclarationPath.node.source;
-                if (
-                  source.value.startsWith(".") &&
-                  /^model(\.(j|t)s)?$/.test(nodePath.basename(source.value))
-                ) {
-                  context = {
-                    importType: "namespace",
-                    importDeclarationPath: importDeclarationPath as Babel.NodePath<
-                      Babel.types.ImportDeclaration
-                    >,
-                    universe: t.identifier(importPath.node.local.name),
-                  };
-                  p.stop();
-                }
+          } else if (
+            t.isVariableDeclarator(bindingPath.node) &&
+            t.isCallExpression(bindingPath.node.init) &&
+            t.isIdentifier(bindingPath.node.init.callee) &&
+            bindingPath.node.init.callee.name === "require" &&
+            bindingPath.node.init.arguments.length === 1 &&
+            t.isStringLiteral(bindingPath.node.init.arguments[0]) &&
+            isModelContextImport(
+              (bindingPath.node.init.arguments[0] as Babel.types.StringLiteral)
+                .value,
+            )
+          ) {
+            universeImports.modelSource = (bindingPath.node.init
+              .arguments[0] as Babel.types.StringLiteral).value.replace(
+              /\.ctx(?=\.(j|t)sx?)?$/,
+              "",
+            );
+            universeImports.programPath = bindingPath.parentPath
+              .parentPath as Babel.NodePath<Babel.types.Program>;
+            if (t.isIdentifier(bindingPath.node.id)) {
+              // const foo = require("./model.ctx");
+              universeImports.namespace = bindingPath.node.id.name;
+            } else if (t.isObjectPattern(bindingPath.node.id)) {
+              const property = bindingPath.node.id.properties.find(
+                (prop: Babel.types.ObjectProperty | Babel.types.RestElement) =>
+                  t.isObjectProperty(prop)
+                    ? t.isIdentifier(prop.value) &&
+                      prop.value.name === p.node.name
+                    : t.isIdentifier(prop.argument) &&
+                      prop.argument.name === p.node.name,
+              );
+              if (property == null) {
+                throw new Error(
+                  "You are using require in a way that the transpiler can't understand.",
+                );
+              }
+              if (t.isObjectProperty(property)) {
+                // const {foo} = require("./model.ctx");
+                universeImports.specifiers[
+                  property.key.name
+                ] = (property.value as Babel.types.Identifier).name;
+              } else {
+                // const {...foo} = require("./model.ctx");
+                universeImports.specifierRest = (property.argument as Babel.types.Identifier).name;
               }
             }
           }
@@ -117,13 +115,61 @@ export default (
     },
   });
 
-  if (context == null) {
+  if (
+    universeImports.namespace == null &&
+    Object.keys(universeImports.specifiers).length === 0 &&
+    universeImports.specifierRest == null
+  ) {
     // Doesn't use the universe, so don't change anything.
     return;
   }
 
-  // https://stackoverflow.com/questions/44147937/property-does-not-exist-on-type-never
-  context = context!;
+  if (
+    universeImports.namespace != null &&
+    (Object.keys(universeImports.specifiers).length > 0 ||
+      universeImports.specifierRest != null)
+  ) {
+    throw new Error(
+      "Cannot import the context as both a namespace and using named imports.",
+    );
+  }
+
+  // Insert `import { model } from "./src/model";
+  if (
+    universeImports.programPath != null &&
+    universeImports.modelSource != null
+  ) {
+    const importDeclarationPath = universeImports.programPath
+      .get("body")
+      .find(
+        expressionPath =>
+          t.isImportDeclaration(expressionPath.node) &&
+          expressionPath.node.source.value === universeImports.modelSource,
+      );
+    if (importDeclarationPath == null) {
+      const importDeclaration = t.importDeclaration(
+        [t.importSpecifier(t.identifier("model"), t.identifier("model"))],
+        t.stringLiteral(universeImports.modelSource),
+      );
+      (universeImports.programPath as any).unshiftContainer(
+        "body",
+        importDeclaration,
+      );
+    } else {
+      const hasModel = (importDeclarationPath.node as Babel.types.ImportDeclaration).specifiers.some(
+        specifier =>
+          t.isImportSpecifier(specifier) &&
+          specifier.local.name === "model" &&
+          specifier.imported.name === "model",
+      );
+      if (!hasModel) {
+        (importDeclarationPath as any).unshiftContainer(
+          "specifiers",
+          t.importSpecifier(t.identifier("model"), t.identifier("model")),
+        );
+      }
+    }
+  }
 
   rootPath.replaceWith(
     t.variableDeclaration("const", [
@@ -131,14 +177,34 @@ export default (
         t.identifier(name),
         t.callExpression(
           t.memberExpression(
-            context.importType === "namespace"
-              ? t.memberExpression(context.universe, t.identifier("model"))
-              : t.identifier("model"),
+            t.identifier("model"),
             t.identifier(type === "action" ? "action" : "connect"),
           ),
           [
             t.arrowFunctionExpression(
-              [context.universe],
+              [
+                universeImports.namespace != null
+                  ? t.identifier(universeImports.namespace)
+                  : t.objectPattern([
+                      ...Object.keys(universeImports.specifiers)
+                        .sort()
+                        .map(key =>
+                          t.objectProperty(
+                            t.identifier(key),
+                            t.identifier(universeImports.specifiers[key]),
+                            false,
+                            key === universeImports.specifiers[key],
+                          ),
+                        ),
+                      ...(universeImports.specifierRest != null
+                        ? [
+                            t.restElement(
+                              t.identifier(universeImports.specifierRest),
+                            ),
+                          ]
+                        : []),
+                    ]),
+              ],
               t.arrowFunctionExpression(params, bodyPath.node, async),
             ),
             t.stringLiteral(name),
@@ -147,19 +213,4 @@ export default (
       ),
     ]),
   );
-
-  if (
-    context.importType === "specifiers" &&
-    !context.importDeclarationPath.node.specifiers.some(
-      specifier =>
-        t.isImportSpecifier(specifier) &&
-        specifier.imported.name === "model" &&
-        specifier.local.name === "model",
-    )
-  ) {
-    (context.importDeclarationPath as any).unshiftContainer(
-      "specifiers",
-      t.importSpecifier(t.identifier("model"), t.identifier("model")),
-    );
-  }
 };

--- a/packages/babel-plugin/tests/actions.test.ts
+++ b/packages/babel-plugin/tests/actions.test.ts
@@ -11,7 +11,7 @@ const transform = (sourceCode: string): string =>
 describe("action transpilation", () => {
   it("can transpile an arrow function action", () => {
     const sourceCode = `
-      import { state } from "./src/model";
+      import { state } from "./src/model.ctx";
       const myAction = () => {
         state.foo = "foo";
       }
@@ -20,7 +20,8 @@ describe("action transpilation", () => {
     const transpiled = transform(sourceCode);
 
     expect(transpiled).toHaveTheSameASTAs(`
-      import { model, state } from "./src/model";
+      import { model } from "./src/model";
+      import { state } from "./src/model.ctx";
       const myAction = model.action(({
         state
       }) => () => {
@@ -29,7 +30,7 @@ describe("action transpilation", () => {
     `);
   });
 
-  it("doesn't transpile something that doesn't use the universe", () => {
+  it("doesn't transpile something that doesn't use the ctx", () => {
     const sourceCode = `
       import { initState } from "./src/model";
       const state = {
@@ -48,7 +49,7 @@ describe("action transpilation", () => {
 
   it("can transpile a function expression action", () => {
     const sourceCode = `
-      import { state } from "./src/model";
+      import { state } from "./src/model.ctx";
       const myAction = function () {
         state.foo = "foo";
       }
@@ -57,7 +58,8 @@ describe("action transpilation", () => {
     const transpiled = transform(sourceCode);
 
     expect(transpiled).toHaveTheSameASTAs(`
-      import { model, state } from "./src/model";
+      import { model } from "./src/model";
+      import { state } from "./src/model.ctx";
       const myAction = model.action(({
         state
       }) => () => {
@@ -68,7 +70,7 @@ describe("action transpilation", () => {
 
   it("can transpile a function declaration action", () => {
     const sourceCode = `
-      import { state } from "./src/model";
+      import { state } from "./src/model.ctx";
       function myAction () {
         state.foo = "foo";
       }
@@ -77,7 +79,8 @@ describe("action transpilation", () => {
     const transpiled = transform(sourceCode);
 
     expect(transpiled).toHaveTheSameASTAs(`
-      import { model, state } from "./src/model";
+      import { model } from "./src/model";
+      import { state } from "./src/model.ctx";
       const myAction = model.action(({
         state
       }) => () => {
@@ -88,7 +91,7 @@ describe("action transpilation", () => {
 
   it("can transpile an action that imports the namespace", () => {
     const sourceCode = `
-      import * as prodo from "./src/model";
+      import * as prodo from "./src/model.ctx";
       const myAction = () => {
         prodo.state.foo = "foo";
       }
@@ -97,8 +100,9 @@ describe("action transpilation", () => {
     const transpiled = transform(sourceCode);
 
     expect(transpiled).toHaveTheSameASTAs(`
-      import * as prodo from "./src/model";
-      const myAction = prodo.model.action(prodo => () => {
+      import { model } from "./src/model";
+      import * as prodo from "./src/model.ctx";
+      const myAction = model.action(prodo => () => {
         prodo.state.foo = "foo";
       }, "myAction");
     `);
@@ -106,7 +110,7 @@ describe("action transpilation", () => {
 
   it("can transpile an action that renames the import", () => {
     const sourceCode = `
-      import { state as s } from "./src/model";
+      import { state as s } from "./src/model.ctx";
       const myAction = () => {
         s.foo = "foo";
       }
@@ -115,7 +119,8 @@ describe("action transpilation", () => {
     const transpiled = transform(sourceCode);
 
     expect(transpiled).toHaveTheSameASTAs(`
-      import { model, state as s } from "./src/model";
+      import { model } from "./src/model";
+      import { state as s } from "./src/model.ctx";
       const myAction = model.action(({
         state: s
       }) => () => {
@@ -126,7 +131,7 @@ describe("action transpilation", () => {
 
   it("can transpile an exported arrow function expression action", () => {
     const sourceCode = `
-      import { state } from "./src/model";
+      import { state } from "./src/model.ctx";
       export const myAction = () => {
         state.foo = "foo";
       }
@@ -135,7 +140,8 @@ describe("action transpilation", () => {
     const transpiled = transform(sourceCode);
 
     expect(transpiled).toHaveTheSameASTAs(`
-      import { model, state } from "./src/model";
+      import { model } from "./src/model";
+      import { state } from "./src/model.ctx";
       export const myAction = model.action(({
         state
       }) => () => {
@@ -146,7 +152,7 @@ describe("action transpilation", () => {
 
   it("can transpile an exported function expression action", () => {
     const sourceCode = `
-      import { state } from "./src/model";
+      import { state } from "./src/model.ctx";
       export const myAction = function () {
         state.foo = "foo";
       }
@@ -155,7 +161,8 @@ describe("action transpilation", () => {
     const transpiled = transform(sourceCode);
 
     expect(transpiled).toHaveTheSameASTAs(`
-      import { model, state } from "./src/model";
+      import { model } from "./src/model";
+      import { state } from "./src/model.ctx";
       export const myAction = model.action(({
         state
       }) => () => {
@@ -166,7 +173,7 @@ describe("action transpilation", () => {
 
   it("can transpile an exported function declaration action", () => {
     const sourceCode = `
-      import { state } from "./src/model";
+      import { state } from "./src/model.ctx";
       export function myAction () {
         state.foo = "foo";
       }
@@ -175,7 +182,8 @@ describe("action transpilation", () => {
     const transpiled = transform(sourceCode);
 
     expect(transpiled).toHaveTheSameASTAs(`
-      import { model, state } from "./src/model";
+      import { model } from "./src/model";
+      import { state } from "./src/model.ctx";
       export const myAction = model.action(({
         state
       }) => () => {
@@ -186,7 +194,7 @@ describe("action transpilation", () => {
 
   it("passes down the universe", () => {
     const sourceCode = `
-      import { state, dispatch as d, effect } from "./src/model";
+      import { dispatch as d, effect, state } from "./src/model.ctx";
       import { anotherAction } from "./another";
       import { myEffect } from "./effect";
       const myAction = () => {
@@ -199,13 +207,14 @@ describe("action transpilation", () => {
     const transpiled = transform(sourceCode);
 
     expect(transpiled).toHaveTheSameASTAs(`
-      import { model, state, dispatch as d, effect } from "./src/model";
+      import { model } from "./src/model";
+      import { dispatch as d, effect, state } from "./src/model.ctx";
       import { anotherAction } from "./another";
       import { myEffect } from "./effect";
       const myAction = model.action(({
-        state,
         dispatch: d,
-        effect
+        effect,
+        state
       }) => () => {
         state.foo = "foo";
         d(anotherAction)();
@@ -216,7 +225,7 @@ describe("action transpilation", () => {
 
   it("passes args", () => {
     const sourceCode = `
-      import { state } from "./src/model";
+      import { state } from "./src/model.ctx";
       const myAction = (foo, {
         bar
       }) => {
@@ -228,7 +237,8 @@ describe("action transpilation", () => {
     const transpiled = transform(sourceCode);
 
     expect(transpiled).toHaveTheSameASTAs(`
-      import { model, state } from "./src/model";
+      import { model } from "./src/model";
+      import { state } from "./src/model.ctx";
       const myAction = model.action(({
         state
       }) => (foo, {
@@ -240,31 +250,9 @@ describe("action transpilation", () => {
     `);
   });
 
-  it("doesn't pass blacklisted imports from the model to the universe", () => {
-    const sourceCode = `
-      import { state, initState } from "./src/model";
-      const foo = initState.foo;
-      const myAction = () => {
-        state.foo = initState.foo;
-      }
-    `;
-
-    const transpiled = transform(sourceCode);
-
-    expect(transpiled).toHaveTheSameASTAs(`
-      import { model, state, initState } from "./src/model";
-      const foo = initState.foo;
-      const myAction = model.action(({
-        state
-      }) => () => {
-        state.foo = initState.foo;
-      }, "myAction");
-    `);
-  });
-
   it("can transpile multiple actions", () => {
     const sourceCode = `
-      import { state } from "./src/model";
+      import { state } from "./src/model.ctx";
       const myAction = () => {
         state.foo = "foo";
       }
@@ -276,7 +264,8 @@ describe("action transpilation", () => {
     const transpiled = transform(sourceCode);
 
     expect(transpiled).toHaveTheSameASTAs(`
-      import { model, state } from "./src/model";
+      import { model } from "./src/model";
+      import { state } from "./src/model.ctx";
       const myAction = model.action(({
         state
       }) => () => {
@@ -292,7 +281,8 @@ describe("action transpilation", () => {
 
   it("doesn't import the model if it's already imported", () => {
     const sourceCode = `
-      import { model, state } from "./src/model";
+      import { model } from "./src/model";
+      import { state } from "./src/model.ctx";
       const myAction = () => {
         state.foo = "foo";
       }
@@ -301,7 +291,8 @@ describe("action transpilation", () => {
     const transpiled = transform(sourceCode);
 
     expect(transpiled).toHaveTheSameASTAs(`
-      import { model, state } from "./src/model";
+      import { model } from "./src/model";
+      import { state } from "./src/model.ctx";
       const myAction = model.action(({
         state
       }) => () => {
@@ -312,7 +303,7 @@ describe("action transpilation", () => {
 
   it("doesn't crash on undefined identifiers", () => {
     const sourceCode = `
-      import { state } from "./src/model";
+      import { state } from "./src/model.ctx";
       const myAction = () => {
         state.foo = foo;
       };
@@ -321,7 +312,8 @@ describe("action transpilation", () => {
     const transpiled = transform(sourceCode);
 
     expect(transpiled).toHaveTheSameASTAs(`
-      import { model, state } from "./src/model";
+      import { model } from "./src/model";
+      import { state } from "./src/model.ctx";
       const myAction = model.action(({
         state
       }) => () => {

--- a/packages/babel-plugin/tests/components.test.tsx
+++ b/packages/babel-plugin/tests/components.test.tsx
@@ -8,10 +8,10 @@ const transform = (sourceCode: string): string =>
     plugins: ["@babel/plugin-syntax-jsx", { visitor: visitor(babel) }],
   })!.code!;
 
-describe("action transpilation", () => {
+describe("component transpilation", () => {
   it("can transpile an arrow function component", () => {
     const sourceCode = `
-      import { state, watch } from "./src/model";
+      import { state, watch } from "./src/model.ctx";
       const MyComponent = () => (
         <div>{watch(state.foo)}</div>
       );
@@ -20,7 +20,8 @@ describe("action transpilation", () => {
     const transpiled = transform(sourceCode);
 
     expect(transpiled).toHaveTheSameASTAs(`
-      import { model, state, watch } from "./src/model";
+      import { model } from "./src/model";
+      import { state, watch } from "./src/model.ctx";
       const MyComponent = model.connect(
         ({ state, watch }) => () => <div>{watch(state.foo)}</div>,
         "MyComponent"
@@ -50,7 +51,7 @@ describe("action transpilation", () => {
 
   it("can transpile a function expression component", () => {
     const sourceCode = `
-      import { state, watch } from "./src/model";
+      import { state, watch } from "./src/model.ctx";
       const MyComponent = function () {
         return <div>{watch(state.foo)}</div>;
       }
@@ -59,7 +60,8 @@ describe("action transpilation", () => {
     const transpiled = transform(sourceCode);
 
     expect(transpiled).toHaveTheSameASTAs(`
-      import { model, state, watch } from "./src/model";
+      import { model } from "./src/model";
+      import { state, watch } from "./src/model.ctx";
       const MyComponent = model.connect(({
         state,
         watch
@@ -71,7 +73,7 @@ describe("action transpilation", () => {
 
   it("can transpile a function declaration component", () => {
     const sourceCode = `
-      import { state, watch } from "./src/model";
+      import { state, watch } from "./src/model.ctx";
       function MyComponent () {
         return <div>{watch(state.foo)}</div>;
       }
@@ -80,7 +82,8 @@ describe("action transpilation", () => {
     const transpiled = transform(sourceCode);
 
     expect(transpiled).toHaveTheSameASTAs(`
-      import { model, state, watch } from "./src/model";
+      import { model } from "./src/model";
+      import { state, watch } from "./src/model.ctx";
       const MyComponent = model.connect(({
         state,
         watch
@@ -92,7 +95,7 @@ describe("action transpilation", () => {
 
   it("can transpile a component that imports the namespace", () => {
     const sourceCode = `
-      import * as prodo from "./src/model";
+      import * as prodo from "./src/model.ctx";
       const MyComponent = () => {
         return <div>{prodo.watch(prodo.state.foo)}</div>;
       }
@@ -101,8 +104,9 @@ describe("action transpilation", () => {
     const transpiled = transform(sourceCode);
 
     expect(transpiled).toHaveTheSameASTAs(`
-      import * as prodo from "./src/model";
-      const MyComponent = prodo.model.connect(prodo => () => {
+      import { model } from "./src/model";
+      import * as prodo from "./src/model.ctx";
+      const MyComponent = model.connect(prodo => () => {
         return <div>{prodo.watch(prodo.state.foo)}</div>;
       }, "MyComponent");
     `);
@@ -110,7 +114,7 @@ describe("action transpilation", () => {
 
   it("can transpile a component that renames the import", () => {
     const sourceCode = `
-      import { state as s, watch as w } from "./src/model";
+      import { state as s, watch as w } from "./src/model.ctx";
       const MyComponent = () => {
         return <div>{w(s.foo)}</div>
       }
@@ -119,7 +123,8 @@ describe("action transpilation", () => {
     const transpiled = transform(sourceCode);
 
     expect(transpiled).toHaveTheSameASTAs(`
-      import { model, state as s, watch as w } from "./src/model";
+      import { model } from "./src/model";
+      import { state as s, watch as w } from "./src/model.ctx";
       const MyComponent = model.connect(({
         state: s,
         watch: w
@@ -131,7 +136,7 @@ describe("action transpilation", () => {
 
   it("can transpile an exported arrow function expression component", () => {
     const sourceCode = `
-      import { state, watch } from "./src/model";
+      import { state, watch } from "./src/model.ctx";
       export const MyComponent = () => {
         return <div>{watch(state.foo)}</div>;
       }
@@ -140,7 +145,8 @@ describe("action transpilation", () => {
     const transpiled = transform(sourceCode);
 
     expect(transpiled).toHaveTheSameASTAs(`
-      import { model, state, watch } from "./src/model";
+      import { model } from "./src/model";
+      import { state, watch } from "./src/model.ctx";
       export const MyComponent = model.connect(({
         state,
         watch
@@ -152,7 +158,7 @@ describe("action transpilation", () => {
 
   it("can transpile an exported function expression component", () => {
     const sourceCode = `
-      import { state, watch } from "./src/model";
+      import { state, watch } from "./src/model.ctx";
       export const MyComponent = function () {
         return <div>{watch(state.foo)}</div>;
       }
@@ -161,7 +167,8 @@ describe("action transpilation", () => {
     const transpiled = transform(sourceCode);
 
     expect(transpiled).toHaveTheSameASTAs(`
-      import { model, state, watch } from "./src/model";
+      import { model } from "./src/model";
+      import { state, watch } from "./src/model.ctx";
       export const MyComponent = model.connect(({
         state,
         watch
@@ -173,7 +180,7 @@ describe("action transpilation", () => {
 
   it("can transpile an exported function declaration component", () => {
     const sourceCode = `
-      import { state, watch } from "./src/model";
+      import { state, watch } from "./src/model.ctx";
       export function MyComponent () {
         return <div>{watch(state.foo)}</div>;
       }
@@ -182,7 +189,8 @@ describe("action transpilation", () => {
     const transpiled = transform(sourceCode);
 
     expect(transpiled).toHaveTheSameASTAs(`
-      import { model, state, watch } from "./src/model";
+      import { model } from "./src/model";
+      import { state, watch } from "./src/model.ctx";
       export const MyComponent = model.connect(({
         state,
         watch
@@ -194,7 +202,7 @@ describe("action transpilation", () => {
 
   it("passes down the universe", () => {
     const sourceCode = `
-      import { state, dispatch as d, watch } from "./src/model";
+      import { dispatch as d, state, watch } from "./src/model.ctx";
       import { anotherAction } from "./another";
       import * as React from "react";
       const MyComponent = () => {
@@ -208,12 +216,13 @@ describe("action transpilation", () => {
     const transpiled = transform(sourceCode);
 
     expect(transpiled).toHaveTheSameASTAs(`
-      import { model, state, dispatch as d, watch } from "./src/model";
+      import { model } from "./src/model";
+      import { dispatch as d, state, watch } from "./src/model.ctx";
       import { anotherAction } from "./another";
       import * as React from "react";
       const MyComponent = model.connect(({
-        state,
         dispatch: d,
+        state,
         watch
       }) => () => {
         React.useEffect(() => {
@@ -226,7 +235,7 @@ describe("action transpilation", () => {
 
   it("passes args", () => {
     const sourceCode = `
-      import { state, watch } from "./src/model";
+      import { state, watch } from "./src/model.ctx";
       const MyComponent = ({
         foo,
         bar
@@ -244,7 +253,8 @@ describe("action transpilation", () => {
     const transpiled = transform(sourceCode);
 
     expect(transpiled).toHaveTheSameASTAs(`
-      import { model, state, watch } from "./src/model";
+      import { model } from "./src/model";
+      import { state, watch } from "./src/model.ctx";
       const MyComponent = model.connect(({
         state,
         watch
@@ -263,42 +273,9 @@ describe("action transpilation", () => {
     `);
   });
 
-  it("doesn't pass blacklisted imports from the model to the universe", () => {
-    const sourceCode = `
-      import { state, initState, watch } from "./src/model";
-      const foo = initState.foo;
-      const MyComponent = () => {
-        return (
-          <div>
-            <div>{initState.foo}</div>
-            <div>{watch(state.foo)}</div>
-          </div>
-        );
-      }
-    `;
-
-    const transpiled = transform(sourceCode);
-
-    expect(transpiled).toHaveTheSameASTAs(`
-      import { model, state, initState, watch } from "./src/model";
-      const foo = initState.foo;
-      const MyComponent = model.connect(({
-        state,
-        watch
-      }) => () => {
-        return (
-          <div>
-            <div>{initState.foo}</div>
-            <div>{watch(state.foo)}</div>
-          </div>
-        );
-      }, "MyComponent");
-    `);
-  });
-
   it("can transpile multiple components", () => {
     const sourceCode = `
-      import { state, watch } from "./src/model";
+      import { state, watch } from "./src/model.ctx";
       const MyComponent = () => {
         return <div>{watch(state.foo)}</div>;
       };
@@ -310,7 +287,8 @@ describe("action transpilation", () => {
     const transpiled = transform(sourceCode);
 
     expect(transpiled).toHaveTheSameASTAs(`
-      import { model, state, watch } from "./src/model";
+      import { model } from "./src/model";
+      import { state, watch } from "./src/model.ctx";
       const MyComponent = model.connect(({
         state,
         watch
@@ -328,7 +306,8 @@ describe("action transpilation", () => {
 
   it("doesn't import the model if it's already imported", () => {
     const sourceCode = `
-      import { model, state, watch } from "./src/model";
+      import { model } from "./src/model";
+      import { state, watch } from "./src/model.ctx";
       const MyComponent = () => {
         return <div>{watch(state.foo)}</div>;
       };
@@ -337,7 +316,8 @@ describe("action transpilation", () => {
     const transpiled = transform(sourceCode);
 
     expect(transpiled).toHaveTheSameASTAs(`
-      import { model, state, watch } from "./src/model";
+      import { model } from "./src/model";
+      import { state, watch } from "./src/model.ctx";
       const MyComponent = model.connect(({
         state,
         watch
@@ -349,7 +329,7 @@ describe("action transpilation", () => {
 
   it("doesn't crash on undefined identifiers", () => {
     const sourceCode = `
-      import { state, watch } from "./src/model";
+      import { state, watch } from "./src/model.ctx";
       const MyComponent = () => {
         return (
           <div>
@@ -363,7 +343,8 @@ describe("action transpilation", () => {
     const transpiled = transform(sourceCode);
 
     expect(transpiled).toHaveTheSameASTAs(`
-      import { model, state, watch } from "./src/model";
+      import { model } from "./src/model";
+      import { state, watch } from "./src/model.ctx";
       const MyComponent = model.connect(({
         state,
         watch


### PR DESCRIPTION
This updates the babel plugin to look for any imports from a files called "model.ctx.ts" (or similar).

It also updates the transpiler to also recognise imports that use `require` (need to add tests for this).