### PR TITLE
fix types for eslint-plugin

### DIFF
--- a/packages/eslint-plugin/tests/rulesTs/require-dispatched-action-is-called.test.ts
+++ b/packages/eslint-plugin/tests/rulesTs/require-dispatched-action-is-called.test.ts
@@ -1,5 +1,5 @@
 import rule from "../../src/rules/require-dispatched-action-is-called";
-import { defaultTsFile, defaultTsxFile, RuleTester } from "../ruleTester";
+import { defaultTsFile, RuleTester } from "../ruleTester";
 
 const ruleTester = new RuleTester({
   parser: require.resolve("@typescript-eslint/parser"),


### PR DESCRIPTION
Fixing types for eslint plugin. Enumerated the possible visitors with 

```
  [key: string]:
    | ((node: TSESTree.ImportDeclaration) => void)
    | ((node: TSESTree.CallExpression) => void)
```
for lack of a better option (to the best of my understanding of typescript) right now and so that I don't just have 'any' as type.