### PR TITLE
Add routing and lint

### DIFF
--- a/examples/kanban/.babelrc
+++ b/examples/kanban/.babelrc
@@ -4,5 +4,6 @@
     "@babel/preset-react",
     "@babel/preset-env"
   ],
-  "plugins": ["@prodo/babel-plugin"]
+  "plugins": ["@prodo/babel-plugin"],
+  "sourceMaps": true
 }

--- a/examples/kanban/.babelrc
+++ b/examples/kanban/.babelrc
@@ -4,6 +4,6 @@
     "@babel/preset-react",
     "@babel/preset-env"
   ],
-  "plugins": ["@prodo/babel-plugin"],
+  "plugins": ["@babel/proposal-class-properties", "@prodo/babel-plugin"],
   "sourceMaps": true
 }

--- a/examples/kanban/package.json
+++ b/examples/kanban/package.json
@@ -10,11 +10,13 @@
     "lint": "set -ex; tsc --build;"
   },
   "dependencies": {
-    "@prodo/core": "^0.0.1",
-    "@prodo/effect": "^0.0.1",
+    "@prodo/core": "^0.0.5",
+    "@prodo/effect": "^0.0.5",
     "@prodo/logger": "^0.0.5",
+    "@prodo/route": "^0.0.5",
     "classnames": "^2.2.5",
     "date-fns": "^1.29.0",
+    "history": "^4.10.1",
     "marked": "^0.3.19",
     "react": "^16.8.6",
     "react-aria-menubutton": "^6.1.0",
@@ -26,7 +28,6 @@
     "react-icons": "^2.2.7",
     "react-modal": "^3.4.4",
     "react-onclickoutside": "^6.7.1",
-    "react-router-dom": "^5.0.1",
     "react-textarea-autosize": "^6.1.0",
     "shortid": "^2.2.8",
     "slugify": "^1.3.0"
@@ -46,7 +47,6 @@
     "@types/react-beautiful-dnd": "^11.0.3",
     "@types/react-dom": "^16.8.5",
     "@types/react-icons": "^2.2.7",
-    "@types/react-router-dom": "^4.3.5",
     "@types/react-textarea-autosize": "^4.3.4",
     "@types/shortid": "^0.0.29",
     "@types/testing-library__react": "^9.1.1",

--- a/examples/kanban/package.json
+++ b/examples/kanban/package.json
@@ -34,6 +34,8 @@
   },
   "devDependencies": {
     "@babel/core": "^7.0.0-0",
+    "@babel/plugin-proposal-class-properties": "^7.5.5",
+    "@babel/polyfill": "^7.6.0",
     "@babel/preset-env": "^7.5.5",
     "@babel/preset-react": "^7.0.0",
     "@babel/preset-typescript": "^7.3.3",
@@ -50,15 +52,18 @@
     "@types/react-textarea-autosize": "^4.3.4",
     "@types/shortid": "^0.0.29",
     "@types/testing-library__react": "^9.1.1",
+    "babel-jest": "^24.9.0",
     "jest": "^24.9.0",
     "parcel-bundler": "^1.12.3",
     "sass": "^1.22.9",
-    "ts-jest": "^24.0.2",
     "typescript": "^3.6.2"
   },
   "jest": {
     "transform": {
-      "^.+\\.tsx?$": "ts-jest"
+      "^.+\\.tsx?$": "babel-jest"
+    },
+    "moduleNameMapper": {
+      "\\.(svg|jpg|scss|css|png)$": "<rootDir>/tests/__mock.js"
     }
   }
 }

--- a/examples/kanban/src/components/App.tsx
+++ b/examples/kanban/src/components/App.tsx
@@ -6,7 +6,7 @@ import BoardContainer from "./Board/BoardContainer";
 import Home from "./Home/Home";
 import LandingPage from "./LandingPage/LandingPage";
 
-const App = ({}) => {
+const AppInner = ({}) => {
   const user = watch(state.user);
   const isGuest = watch(state.isGuest);
   // Serve different pages depending on if user is logged in or not
@@ -30,4 +30,9 @@ const App = ({}) => {
 
 // Use withRouter to prevent strange glitch where other components
 // lower down in the component tree wouldn't update from URL changes
-export default App;
+export default () => (
+  <>
+    <AppInner />
+    <div id="modal" />
+  </>
+);

--- a/examples/kanban/src/components/App.tsx
+++ b/examples/kanban/src/components/App.tsx
@@ -1,10 +1,10 @@
+import { Redirect, Route, Switch } from "@prodo/route";
 import * as React from "react";
-import { Route, Redirect, Switch, withRouter } from "react-router-dom";
-import Home from "./Home/Home";
-import BoardContainer from "./Board/BoardContainer";
-import LandingPage from "./LandingPage/LandingPage";
+import { state, watch } from "../model";
 import "./App.scss";
-import { watch, state } from "../model";
+import BoardContainer from "./Board/BoardContainer";
+import Home from "./Home/Home";
+import LandingPage from "./LandingPage/LandingPage";
 
 const App = ({}) => {
   const user = watch(state.user);
@@ -30,4 +30,4 @@ const App = ({}) => {
 
 // Use withRouter to prevent strange glitch where other components
 // lower down in the component tree wouldn't update from URL changes
-export default withRouter(App);
+export default App;

--- a/examples/kanban/src/components/Board/Board.tsx
+++ b/examples/kanban/src/components/Board/Board.tsx
@@ -1,18 +1,18 @@
-import * as React from "react";
-import { Title } from "react-head";
-import { DragDropContext, Droppable } from "react-beautiful-dnd";
 import classnames from "classnames";
+import * as React from "react";
+import { DragDropContext, Droppable } from "react-beautiful-dnd";
+import { Title } from "react-head";
+import { dispatch, state, watch } from "../../model";
+import { Board as _Board } from "../../types";
+import BoardHeader from "../BoardHeader/BoardHeader";
+import Header from "../Header/Header";
 import List from "../List/List";
 import ListAdder from "../ListAdder/ListAdder";
-import Header from "../Header/Header";
-import BoardHeader from "../BoardHeader/BoardHeader";
 import "./Board.scss";
-import { Board as _Board } from "../../types";
-import { watch, state, dispatch } from "../../model";
 
-type Props = {
+interface Props {
   boardId: string;
-};
+}
 
 function setCurrentBoard(boardId) {
   state.currentBoardId = boardId;

--- a/examples/kanban/src/components/Board/BoardContainer.tsx
+++ b/examples/kanban/src/components/Board/BoardContainer.tsx
@@ -1,5 +1,6 @@
 import { Redirect } from "@prodo/route";
 import * as React from "react";
+import { state, watch } from "../../model";
 import Board from "./Board";
 
 // This components only purpose is to redirect requests for board pages that don't exist
@@ -9,7 +10,8 @@ interface Props {
 }
 
 function BoardContainer({ boardId }: Props) {
-  return boardId ? <Board boardId={boardId} /> : <Redirect to="/" />;
+  const board = watch(state.boardsById[boardId]);
+  return board ? <Board boardId={boardId} /> : <Redirect to="/" />;
 }
 
 export default BoardContainer;

--- a/examples/kanban/src/components/Board/BoardContainer.tsx
+++ b/examples/kanban/src/components/Board/BoardContainer.tsx
@@ -1,17 +1,14 @@
+import { Redirect } from "@prodo/route";
 import * as React from "react";
-import { Redirect } from "react-router";
 import Board from "./Board";
-
-type Props = {
-  match: {
-    params: { boardId: string };
-  };
-};
 
 // This components only purpose is to redirect requests for board pages that don't exist
 // or which the user is not authorized to visit, in order to prevent errors
-function BoardContainer({ match }: Props) {
-  const { boardId } = match.params;
+interface Props {
+  boardId: string;
+}
+
+function BoardContainer({ boardId }: Props) {
   return boardId ? <Board boardId={boardId} /> : <Redirect to="/" />;
 }
 

--- a/examples/kanban/src/components/BoardHeader/BoardDeleter.tsx
+++ b/examples/kanban/src/components/BoardHeader/BoardDeleter.tsx
@@ -1,29 +1,21 @@
+import { matchRoute, push } from "@prodo/route";
 import * as React from "react";
-import { withRouter } from "react-router-dom";
-import { Button, Wrapper, Menu, MenuItem } from "react-aria-menubutton";
+import { Button, Menu, MenuItem, Wrapper } from "react-aria-menubutton";
 // @ts-ignore
 import FaTrash from "react-icons/lib/fa/trash";
+import { dispatch, route, state, watch } from "../../model";
 import "./BoardDeleter.scss";
-import { state, dispatch } from "../../model";
-
-type Props = {
-  match: {
-    params: {
-      boardId: string;
-    };
-  };
-  history: { push: Function };
-};
 
 function deleteBoard(boardId) {
   delete state.boardsById[boardId];
+  dispatch(push)("/");
 }
 
-function BoardDeleter({ match, history }: Props) {
+function BoardDeleter() {
   const handleSelection = () => {
-    const { boardId } = match.params;
+    const path = watch(route.path);
+    const { boardId } = matchRoute(path, "/b/:boardId");
     dispatch(deleteBoard)(boardId);
-    history.push("/");
   };
   return (
     <Wrapper className="board-deleter-wrapper" onSelection={handleSelection}>
@@ -41,4 +33,4 @@ function BoardDeleter({ match, history }: Props) {
   );
 }
 
-export default withRouter(BoardDeleter);
+export default BoardDeleter;

--- a/examples/kanban/src/components/BoardHeader/BoardDeleter.tsx
+++ b/examples/kanban/src/components/BoardHeader/BoardDeleter.tsx
@@ -1,4 +1,4 @@
-import { matchRoute, push } from "@prodo/route";
+import { matchRoute } from "@prodo/route";
 import * as React from "react";
 import { Button, Menu, MenuItem, Wrapper } from "react-aria-menubutton";
 // @ts-ignore
@@ -8,7 +8,6 @@ import "./BoardDeleter.scss";
 
 function deleteBoard(boardId) {
   delete state.boardsById[boardId];
-  dispatch(push)("/");
 }
 
 function BoardDeleter() {

--- a/examples/kanban/src/components/BoardHeader/BoardHeader.tsx
+++ b/examples/kanban/src/components/BoardHeader/BoardHeader.tsx
@@ -1,8 +1,8 @@
 import * as React from "react";
-import BoardTitle from "./BoardTitle";
-import ColorPicker from "./ColorPicker";
 import BoardDeleter from "./BoardDeleter";
 import "./BoardHeader.scss";
+import BoardTitle from "./BoardTitle";
+import ColorPicker from "./ColorPicker";
 
 const BoardHeader = () => (
   <div className="board-header">

--- a/examples/kanban/src/components/BoardHeader/BoardTitle.tsx
+++ b/examples/kanban/src/components/BoardHeader/BoardTitle.tsx
@@ -1,22 +1,15 @@
+import { matchRoute } from "@prodo/route";
 import * as React from "react";
-import { withRouter } from "react-router-dom";
+import { dispatch, route, state, watch } from "../../model";
 import "./BoardTitle.scss";
-import { dispatch, state, watch } from "../../model";
-
-type Props = {
-  match: {
-    params: {
-      boardId: string;
-    };
-  };
-};
 
 function changeBoardTitle(boardId: string, newTitle: string) {
   state.boardsById[boardId].title = newTitle;
 }
 
-function BoardTitle({ match }: Props) {
-  const { boardId } = match.params;
+function BoardTitle() {
+  const path = watch(route.path);
+  const { boardId } = matchRoute(path, "/b/:boardId");
   const boardTitle = watch(state.boardsById[boardId].title);
   const [isOpen, setOpen] = React.useState(false);
   const [newTitle, setNewTitle] = React.useState(boardTitle);
@@ -26,7 +19,9 @@ function BoardTitle({ match }: Props) {
   const handleChange = (event: any) => setNewTitle(event.target.value);
 
   const submitTitle = () => {
-    if (newTitle === "") return;
+    if (newTitle === "") {
+      return;
+    }
     if (boardTitle !== newTitle) {
       dispatch(changeBoardTitle)(boardId, newTitle);
     }
@@ -69,4 +64,4 @@ function BoardTitle({ match }: Props) {
   );
 }
 
-export default withRouter(BoardTitle);
+export default BoardTitle;

--- a/examples/kanban/src/components/BoardHeader/ColorPicker.tsx
+++ b/examples/kanban/src/components/BoardHeader/ColorPicker.tsx
@@ -1,25 +1,21 @@
-import * as React from "react";
-import { withRouter } from "react-router-dom";
-import { Button, Wrapper, Menu, MenuItem } from "react-aria-menubutton";
+import { matchRoute } from "@prodo/route";
 import classnames from "classnames";
+import * as React from "react";
+import { Button, Menu, MenuItem, Wrapper } from "react-aria-menubutton";
 // @ts-ignore
 import FaCheck from "react-icons/lib/fa/check";
 // @ts-ignore
 import colorIcon from "../../assets/images/color-icon.png";
+import { dispatch, route, state, watch } from "../../model";
 import "./ColorPicker.scss";
-import { state, watch, dispatch } from "../../model";
-
-type Props = {
-  match: { params: { boardId: string } };
-};
 
 function changeBoardColor(boardId, color) {
-  console.log("changeBoardColor", { boardId, color });
   state.boardsById[boardId].color = color;
 }
 
-function ColorPicker({ match }: Props) {
-  const { boardId } = match.params;
+function ColorPicker() {
+  const path = watch(route.path);
+  const { boardId } = matchRoute(path, "/b/:boardId");
   const boardColor = watch(state.boardsById[boardId].color);
 
   const colors = ["blue", "green", "red", "pink"];
@@ -49,4 +45,4 @@ function ColorPicker({ match }: Props) {
   );
 }
 
-export default withRouter(ColorPicker);
+export default ColorPicker;

--- a/examples/kanban/src/components/Card/Card.tsx
+++ b/examples/kanban/src/components/Card/Card.tsx
@@ -1,13 +1,13 @@
+import classnames from "classnames";
 import * as React from "react";
 import { Draggable } from "react-beautiful-dnd";
-import classnames from "classnames";
-import CardModal from "../CardModal/CardModal";
-import CardBadges from "../CardBadges/CardBadges";
-import formatMarkdown from "./formatMarkdown";
-import { findCheckboxes } from "../utils";
 import { state, watch } from "../../model";
 import { Card as _Card } from "../../types";
+import CardBadges from "../CardBadges/CardBadges";
+import CardModal from "../CardModal/CardModal";
+import { findCheckboxes } from "../utils";
 import "./Card.scss";
+import formatMarkdown from "./formatMarkdown";
 
 const toggleCheckbox = (card: _Card, checked: boolean, i: number) => {
   // identify the clicked checkbox by its index and give it a new checked attribute
@@ -21,12 +21,12 @@ const toggleCheckbox = (card: _Card, checked: boolean, i: number) => {
   state.cardsById[_id].text = newText;
 };
 
-type Props = {
+interface Props {
   cardId: string;
   listId: string;
   isDraggingOver: boolean;
   index: number;
-};
+}
 
 export function Card({ cardId, listId, isDraggingOver, index }: Props) {
   const card = watch(state.cardsById[cardId]);

--- a/examples/kanban/src/components/CardAdder/CardAdder.tsx
+++ b/examples/kanban/src/components/CardAdder/CardAdder.tsx
@@ -1,13 +1,13 @@
 import * as React from "react";
 import Textarea from "react-textarea-autosize";
 import * as shortid from "shortid";
+import { dispatch, state } from "../../model";
 import ClickOutside from "../ClickOutside/ClickOutside";
 import "./CardAdder.scss";
-import { dispatch, state } from "../../model";
 
-type Props = {
+interface Props {
   listId: string;
-};
+}
 
 function addCard(newText: string, cardId: string, listId: string) {
   state.listsById[listId].cards.push(cardId);
@@ -17,7 +17,7 @@ function addCard(newText: string, cardId: string, listId: string) {
 function CardAdder({ listId }: Props) {
   const [localState, setLocalState] = React.useState({
     newText: "",
-    isOpen: false
+    isOpen: false,
   });
   const { newText, isOpen } = localState;
 
@@ -39,7 +39,9 @@ function CardAdder({ listId }: Props) {
 
   const handleSubmit = (event: any) => {
     event.preventDefault();
-    if (newText === "") return;
+    if (newText === "") {
+      return;
+    }
     const cardId = shortid.generate();
     dispatch(addCard)(newText, cardId, listId);
     toggleCardComposer();

--- a/examples/kanban/src/components/CardBadges/CardBadges.tsx
+++ b/examples/kanban/src/components/CardBadges/CardBadges.tsx
@@ -1,21 +1,21 @@
-import * as React from "react";
-// @ts-ignore
-import format from "date-fns/format";
 // @ts-ignore
 import differenceInCalendarDays from "date-fns/difference_in_calendar_days";
 // @ts-ignore
-import MdAlarm from "react-icons/lib/md/access-alarm";
+import format from "date-fns/format";
+import * as React from "react";
 // @ts-ignore
 import MdDoneAll from "react-icons/lib/fa/check-square-o";
+// @ts-ignore
+import MdAlarm from "react-icons/lib/md/access-alarm";
 import "./CardBadges.scss";
 
-type Props = {
+interface Props {
   date: Date;
   checkboxes: {
     total: number;
     checked: number;
   };
-};
+}
 
 function DueDate({ date }: Partial<Props>) {
   if (!date) {

--- a/examples/kanban/src/components/CardModal/Calendar.tsx
+++ b/examples/kanban/src/components/CardModal/Calendar.tsx
@@ -1,13 +1,13 @@
 import * as React from "react";
 import DayPicker from "react-day-picker";
-import "./ReactDayPicker.css";
 import { dispatch, state } from "../../model";
+import "./ReactDayPicker.css";
 
-type Props = {
+interface Props {
   cardId: string;
   date?: string | Date;
-  toggleCalendar: Function;
-};
+  toggleCalendar: (...args: any[]) => any;
+}
 
 function changeCardDate(date: Date, cardId: string) {
   state.cardsById[cardId].date = date;
@@ -15,13 +15,15 @@ function changeCardDate(date: Date, cardId: string) {
 
 function Calendar({ cardId, date, toggleCalendar }: Props) {
   const [selectedDay, selectDay] = React.useState(
-    date ? new Date(date) : undefined
+    date ? new Date(date) : undefined,
   );
   return (
     <div className="calendar">
       <DayPicker
         onDayClick={(day, { selected, disabled }) => {
-          if (disabled) return;
+          if (disabled) {
+            return;
+          }
           selectDay(selected ? undefined : day);
         }}
         selectedDays={selectedDay}

--- a/examples/kanban/src/components/CardModal/CardModal.tsx
+++ b/examples/kanban/src/components/CardModal/CardModal.tsx
@@ -40,7 +40,7 @@ function CardModal({
   const [isTextareaFocused, setTextareaFocused] = React.useState(true);
 
   if (typeof document !== "undefined") {
-    Modal.setAppElement("#app");
+    Modal.setAppElement("#modal");
   }
 
   const handleKeyDown = (event: any) => {

--- a/examples/kanban/src/components/CardModal/CardModal.tsx
+++ b/examples/kanban/src/components/CardModal/CardModal.tsx
@@ -1,22 +1,22 @@
 import * as React from "react";
-import Textarea from "react-textarea-autosize";
 import Modal from "react-modal";
+import Textarea from "react-textarea-autosize";
+import { dispatch, state } from "../../model";
+import { Card } from "../../types";
 import CardBadges from "../CardBadges/CardBadges";
-import CardOptions from "./CardOptions";
 import { findCheckboxes } from "../utils";
 import "./CardModal.scss";
-import { Card } from "../../types";
-import { state, dispatch } from "../../model";
+import CardOptions from "./CardOptions";
 
-type Props = {
+interface Props {
   card: Card;
   cardElement: {
-    getBoundingClientRect: Function;
+    getBoundingClientRect: (...args: any[]) => any;
   };
   isOpen: boolean;
-  toggleCardEditor: Function;
+  toggleCardEditor: (...args: any[]) => any;
   listId: string;
-};
+}
 
 function changeCardText(_id: string, text: string) {
   state.cardsById[_id].text = text;
@@ -33,7 +33,7 @@ function CardModal({
   listId,
   cardElement,
   isOpen,
-  toggleCardEditor
+  toggleCardEditor,
 }: Props) {
   const [newText, setNewText] = React.useState(card.text);
   const [isColorPickerOpen, setColorPickerOpen] = React.useState(false);
@@ -100,14 +100,14 @@ function CardModal({
     content: {
       top: Math.min(
         boundingRect.top,
-        window.innerHeight - boundingRect.height - 18
+        window.innerHeight - boundingRect.height - 18,
       ),
       left: isCardNearRightBorder ? null : boundingRect.left,
       right: isCardNearRightBorder
         ? window.innerWidth - boundingRect.right
         : null,
-      flexDirection: isCardNearRightBorder ? "row-reverse" : "row"
-    }
+      flexDirection: isCardNearRightBorder ? "row-reverse" : "row",
+    },
   };
 
   // For layouts that are less wide than 550px, let the modal take up the entire width at the top of the screen
@@ -116,8 +116,8 @@ function CardModal({
       flexDirection: "column",
       top: 3,
       left: 3,
-      right: 3
-    }
+      right: 3,
+    },
   };
 
   return (
@@ -140,7 +140,7 @@ function CardModal({
           boxShadow: isTextareaFocused
             ? "0px 0px 3px 2px rgb(0, 180, 255)"
             : null,
-          background: card.color
+          background: card.color,
         }}
       >
         <Textarea

--- a/examples/kanban/src/components/CardModal/CardOptions.tsx
+++ b/examples/kanban/src/components/CardModal/CardOptions.tsx
@@ -1,25 +1,25 @@
 import * as React from "react";
-import Modal from "react-modal";
-//@ts-ignore
+// @ts-ignore
 import FaTrash from "react-icons/lib/fa/trash";
-//@ts-ignore
+// @ts-ignore
 import MdAlarm from "react-icons/lib/md/access-alarm";
-import Calendar from "./Calendar";
-import ClickOutside from "../ClickOutside/ClickOutside";
-//@ts-ignore
+import Modal from "react-modal";
+// @ts-ignore
 import colorIcon from "../../assets/images/color-icon.png";
-import "./CardOptions.scss";
+import { dispatch, state } from "../../model";
 import { Card } from "../../types";
-import { state, dispatch } from "../../model";
+import ClickOutside from "../ClickOutside/ClickOutside";
+import Calendar from "./Calendar";
+import "./CardOptions.scss";
 
-type Props = {
+interface Props {
   isColorPickerOpen: boolean;
   card: Card;
   isCardNearRightBorder: boolean;
   isThinDisplay: boolean;
   boundingRect: { bottom: any; left: any };
-  toggleColorPicker: Function;
-};
+  toggleColorPicker: (...args: any[]) => any;
+}
 
 function changeCardColor(_id: string, color: string) {
   state.cardsById[_id].color = color;
@@ -35,7 +35,7 @@ function CardOptions({
   isCardNearRightBorder,
   isThinDisplay,
   boundingRect,
-  toggleColorPicker
+  toggleColorPicker,
 }: Props) {
   const [isCalendarOpen, setCalendarOpen] = React.useState(false);
   let colorPickerButton: any;
@@ -67,22 +67,22 @@ function CardOptions({
   const calendarStyle = {
     content: {
       top: Math.min(boundingRect.bottom + 10, window.innerHeight - 300),
-      left: boundingRect.left
-    }
+      left: boundingRect.left,
+    },
   };
 
   const calendarMobileStyle = {
     content: {
       top: 110,
       left: "50%",
-      transform: "translateX(-50%)"
-    }
+      transform: "translateX(-50%)",
+    },
   };
   return (
     <div
       className="options-list"
       style={{
-        alignItems: isCardNearRightBorder ? "flex-end" : "flex-start"
+        alignItems: isCardNearRightBorder ? "flex-end" : "flex-start",
       }}
     >
       <div>

--- a/examples/kanban/src/components/ClickOutside/ClickOutside.tsx
+++ b/examples/kanban/src/components/ClickOutside/ClickOutside.tsx
@@ -5,8 +5,8 @@ import onClickOutside from "react-onclickoutside";
 // Wrap component in this component to handle click outisde of that component
 class ClickOutsideWrapper extends Component {
   // @ts-ignore
-  handleClickOutside = () => this.props.handleClickOutside();
-  render = () => this.props.children;
+  public handleClickOutside = () => this.props.handleClickOutside();
+  public render = () => this.props.children;
 }
 
 export default onClickOutside(ClickOutsideWrapper);

--- a/examples/kanban/src/components/Header/Header.tsx
+++ b/examples/kanban/src/components/Header/Header.tsx
@@ -1,15 +1,15 @@
+import { Link } from "@prodo/route";
 import * as React from "react";
-import { Link } from "react-router-dom";
-// @ts-ignore
-import FaUserSecret from "react-icons/lib/fa/user-secret";
-// @ts-ignore
-import FaSignOut from "react-icons/lib/fa/sign-out";
 // @ts-ignore
 import FaSignIn from "react-icons/lib/fa/sign-in";
 // @ts-ignore
+import FaSignOut from "react-icons/lib/fa/sign-out";
+// @ts-ignore
+import FaUserSecret from "react-icons/lib/fa/user-secret";
+// @ts-ignore
 import kanbanLogo from "../../assets/images/kanban-logo.svg";
-import "./Header.scss";
 import { state, watch } from "../../model";
+import "./Header.scss";
 
 function Header() {
   const user = watch(state.user);

--- a/examples/kanban/src/components/Home/BoardAdder.tsx
+++ b/examples/kanban/src/components/Home/BoardAdder.tsx
@@ -1,13 +1,9 @@
+import { push } from "@prodo/route";
 import * as React from "react";
-import slugify from "slugify";
 import shortid from "shortid";
+import slugify from "slugify";
+import { dispatch, state, watch } from "../../model";
 import ClickOutside from "../ClickOutside/ClickOutside";
-import { state, dispatch, watch } from "../../model";
-import { withRouter } from "react-router-dom";
-
-type Props = {
-  history: any;
-};
 
 function addBoard(boardId: string, userId: string, title: string) {
   state.boardsById[boardId] = {
@@ -15,17 +11,20 @@ function addBoard(boardId: string, userId: string, title: string) {
     title,
     lists: [],
     users: [userId],
-    color: "blue"
+    color: "blue",
   };
   state.currentBoardId = boardId;
+
+  const urlSlug = slugify(title, { lower: true });
+  dispatch(push)(`/b/${boardId}/${urlSlug}`);
 }
 
-function BoardAdder({ history }: Props) {
+function BoardAdder() {
   const user = watch(state.user);
   const userId = user ? user._id : "guest";
   const [localState, setLocalState] = React.useState({
     isOpen: false,
-    title: ""
+    title: "",
   });
   const { isOpen, title } = localState;
 
@@ -45,8 +44,6 @@ function BoardAdder({ history }: Props) {
     }
     const boardId = shortid.generate();
     dispatch(addBoard)(boardId, userId, title);
-    const urlSlug = slugify(title, { lower: true });
-    history.push(`/b/${boardId}/${urlSlug}`);
     setLocalState({ isOpen: false, title: "" });
   };
 
@@ -83,4 +80,4 @@ function BoardAdder({ history }: Props) {
   );
 }
 
-export default withRouter(BoardAdder);
+export default BoardAdder;

--- a/examples/kanban/src/components/Home/Home.tsx
+++ b/examples/kanban/src/components/Home/Home.tsx
@@ -24,6 +24,7 @@ function Home() {
               <Link
                 key={board._id}
                 className={classnames("board-link", board.color)}
+                data-testid={`button-${board.title}`}
                 to={`/b/${board._id}/${slugify(board.title, {
                   lower: true,
                 })}`}

--- a/examples/kanban/src/components/Home/Home.tsx
+++ b/examples/kanban/src/components/Home/Home.tsx
@@ -1,12 +1,12 @@
+import { Link } from "@prodo/route";
+import classnames from "classnames";
 import * as React from "react";
-import { Link } from "react-router-dom";
 import { Title } from "react-head";
 import slugify from "slugify";
-import classnames from "classnames";
+import { state, watch } from "../../model";
 import Header from "../Header/Header";
 import BoardAdder from "./BoardAdder";
 import "./Home.scss";
-import { state, watch } from "../../model";
 
 function Home() {
   const boardsById = watch(state.boardsById);
@@ -25,7 +25,7 @@ function Home() {
                 key={board._id}
                 className={classnames("board-link", board.color)}
                 to={`/b/${board._id}/${slugify(board.title, {
-                  lower: true
+                  lower: true,
                 })}`}
               >
                 <div className="board-link-title">{board.title}</div>
@@ -37,8 +37,8 @@ function Home() {
                       style={{
                         height: `${Math.min(
                           (listsById[listId].cards.length + 1) * 18,
-                          100
-                        )}%`
+                          100,
+                        )}%`,
                       }}
                     />
                   ))}

--- a/examples/kanban/src/components/List/Cards.tsx
+++ b/examples/kanban/src/components/List/Cards.tsx
@@ -1,11 +1,11 @@
 import * as React from "react";
 import { Droppable } from "react-beautiful-dnd";
+import { state, watch } from "../../model";
 import Card from "../Card/Card";
-import { watch, state } from "../../model";
 
-type Props = {
+interface Props {
   listId: string;
-};
+}
 
 function Cards({ listId }: Props) {
   const cards = watch(state.listsById[listId].cards);

--- a/examples/kanban/src/components/List/List.tsx
+++ b/examples/kanban/src/components/List/List.tsx
@@ -1,17 +1,17 @@
+import classnames from "classnames";
 import * as React from "react";
 import { Draggable } from "react-beautiful-dnd";
-import classnames from "classnames";
-import ListHeader from "./ListHeader";
-import Cards from "./Cards";
-import CardAdder from "../CardAdder/CardAdder";
-import "./List.scss";
 import { List as _List } from "../../types";
+import CardAdder from "../CardAdder/CardAdder";
+import Cards from "./Cards";
+import "./List.scss";
+import ListHeader from "./ListHeader";
 
-type Props = {
+interface Props {
   boardId: string;
   index: number;
   list: _List;
-};
+}
 
 function List({ boardId, index, list }: Props) {
   return (
@@ -29,7 +29,7 @@ function List({ boardId, index, list }: Props) {
           >
             <div
               className={classnames("list", {
-                "list--drag": snapshot.isDragging
+                "list--drag": snapshot.isDragging,
               })}
             >
               <ListHeader

--- a/examples/kanban/src/components/List/ListHeader.tsx
+++ b/examples/kanban/src/components/List/ListHeader.tsx
@@ -1,19 +1,19 @@
 import * as React from "react";
-import Textarea from "react-textarea-autosize";
-import { Button, Wrapper, Menu, MenuItem } from "react-aria-menubutton";
+import { Button, Menu, MenuItem, Wrapper } from "react-aria-menubutton";
 // @ts-ignore
 import FaTrash from "react-icons/lib/fa/trash";
+import Textarea from "react-textarea-autosize";
 import "./ListHeader.scss";
 
 import { dispatch, state } from "../../model";
 
-type Props = {
+interface Props {
   listTitle: string;
   listId: string;
   boardId: string;
   cards: string[];
   dragHandleProps: any;
-};
+}
 
 function changeListTitle(listId: string, newTitle: string) {
   state.listsById[listId].title = newTitle;
@@ -33,11 +33,11 @@ function ListTitle({
   listId,
   boardId,
   cards,
-  dragHandleProps
+  dragHandleProps,
 }: Props) {
   const [localState, setLocalState] = React.useState({
     isOpen: false,
-    newTitle: listTitle
+    newTitle: listTitle,
   });
   const { isOpen, newTitle } = localState;
 
@@ -55,9 +55,11 @@ function ListTitle({
   };
 
   const handleSubmit = () => {
-    if (newTitle === "") return;
+    if (newTitle === "") {
+      return;
+    }
     if (newTitle !== listTitle) {
-      dispatch(changeListTitle)(listId, newTitle), {};
+      dispatch(changeListTitle)(listId, newTitle);
     }
     setLocalState({ isOpen: false, newTitle });
   };

--- a/examples/kanban/src/components/ListAdder/ListAdder.tsx
+++ b/examples/kanban/src/components/ListAdder/ListAdder.tsx
@@ -1,12 +1,12 @@
 import * as React from "react";
 import Textarea from "react-textarea-autosize";
 import * as shortid from "shortid";
-import "./ListAdder.scss";
 import { dispatch, state } from "../../model";
+import "./ListAdder.scss";
 
-type Props = {
+interface Props {
   boardId: string;
-};
+}
 
 function addList(boardId: string, listId: string, listTitle: string) {
   state.boardsById[boardId].lists.push(listId);
@@ -38,7 +38,9 @@ function ListAdder({ boardId }: Props) {
     }
   };
   const handleSubmit = () => {
-    if (listTitle === "") return;
+    if (listTitle === "") {
+      return;
+    }
     const listId = shortid.generate();
     dispatch(addList)(boardId, listId, listTitle);
     setLocalState({ isOpen: false, listTitle: "" });

--- a/examples/kanban/src/index.html
+++ b/examples/kanban/src/index.html
@@ -8,7 +8,6 @@
   </head>
   <body>
     <div id="root"></div>
-    <div id="app"></div>
     <script src="./main.tsx"></script>
   </body>
 </html>

--- a/examples/kanban/src/main.tsx
+++ b/examples/kanban/src/main.tsx
@@ -1,22 +1,18 @@
-import { ProdoProvider } from "@prodo/core";
 import * as React from "react";
 import * as ReactDOM from "react-dom";
-import { BrowserRouter } from "react-router-dom";
 import ErrorBoundary from "react-error-boundary";
 import App from "./components/App";
-import store from "./store";
+import { Provider, store } from "./store";
 import "./styles.scss";
 
-//@ts-ignore
+// @ts-ignore
 window.store = store; // for debugging
 
 ReactDOM.render(
   <ErrorBoundary>
-    <BrowserRouter>
-      <ProdoProvider value={store}>
-        <App />
-      </ProdoProvider>
-    </BrowserRouter>
+    <Provider>
+      <App />
+    </Provider>
   </ErrorBoundary>,
-  document.getElementById("root")
+  document.getElementById("root"),
 );

--- a/examples/kanban/src/model.tsx
+++ b/examples/kanban/src/model.tsx
@@ -1,8 +1,10 @@
 import { createModel } from "@prodo/core";
-import effect from "@prodo/effect";
-import logger from "@prodo/logger";
+import effectPlugin from "@prodo/effect";
+import loggerPlugin from "@prodo/logger";
+import routePlugin from "@prodo/route";
 import { State } from "./types";
 export const model = createModel<State>()
-  .with(effect)
-  .with(logger);
-export const { state, watch, dispatch } = model.ctx;
+  .with(effectPlugin)
+  .with(loggerPlugin)
+  .with(routePlugin);
+export const { state, watch, dispatch, effect, route } = model.ctx;

--- a/examples/kanban/src/store.tsx
+++ b/examples/kanban/src/store.tsx
@@ -1,5 +1,8 @@
+import { createBrowserHistory } from "history";
 import { model } from "./model";
-export default model.createStore({
+
+const history = createBrowserHistory();
+export const { store, Provider } = model.createStore({
   logger: true,
   initState: {
     user: {
@@ -26,5 +29,8 @@ export default model.createStore({
       C2: { _id: "C2", text: "World", date: new Date(), color: "green" },
       C3: { _id: "C3", text: "everything", date: new Date(), color: "blue" },
     },
+  },
+  route: {
+    history,
   },
 });

--- a/examples/kanban/tests/__mock.js
+++ b/examples/kanban/tests/__mock.js
@@ -1,0 +1,3 @@
+// some silly boilerplate for jest...
+// see usage in package.json/jest.moduleNameMapper
+module.exports = "";

--- a/examples/kanban/tests/fixtures.tsx
+++ b/examples/kanban/tests/fixtures.tsx
@@ -1,0 +1,27 @@
+import { State } from "../src/types";
+export const initState: State = {
+  user: {
+    _id: "ted",
+    name: "ted",
+    imageUrl: "https://profiles.utdallas.edu/img/default.png",
+  },
+  currentBoardId: "B1",
+  boardsById: {
+    B1: {
+      _id: "B1",
+      title: "todos",
+      color: "blue",
+      lists: ["L1", "L2"],
+      users: ["ted"],
+    },
+  },
+  listsById: {
+    L1: { _id: "L1", title: "doing", cards: ["C1", "C2"] },
+    L2: { _id: "L2", title: "done-ish", cards: ["C3"] },
+  },
+  cardsById: {
+    C1: { _id: "C1", text: "Hello", date: new Date(), color: "white" },
+    C2: { _id: "C2", text: "World", date: new Date(), color: "green" },
+    C3: { _id: "C3", text: "everything", date: new Date(), color: "blue" },
+  },
+};

--- a/examples/kanban/tests/render.test.tsx
+++ b/examples/kanban/tests/render.test.tsx
@@ -1,0 +1,42 @@
+import "@babel/polyfill";
+import { fireEvent, render, waitForDomChange } from "@testing-library/react";
+import { createMemoryHistory } from "history";
+import * as React from "react";
+import App from "../src/components/App";
+import { model } from "../src/model";
+import { initState } from "./fixtures";
+
+describe("components", () => {
+  it("can render with initial store", async () => {
+    const { Provider, store } = model.createStore({
+      initState,
+      route: { history: createMemoryHistory() },
+      logger: false,
+    });
+    render(
+      <Provider>
+        <App />
+      </Provider>,
+    );
+  });
+
+  it("can open a board", async () => {
+    const { Provider, store } = model.createStore({
+      initState,
+      route: { history: createMemoryHistory() },
+      logger: false,
+    });
+
+    const { container, getByTestId } = render(
+      <Provider>
+        <App />
+      </Provider>,
+    );
+
+    const button = getByTestId("button-todos");
+    fireEvent.click(button);
+
+    await waitForDomChange({ container });
+    expect(store.universe.route.path).toBe("/b/B1/todos");
+  });
+});

--- a/examples/kanban/tsconfig.json
+++ b/examples/kanban/tsconfig.json
@@ -24,6 +24,7 @@
     { "path": "../../packages/core" },
     { "path": "../../packages/effect-plugin" },
     { "path": "../../packages/logger-plugin" },
+    { "path": "../../packages/route-plugin" },
     { "path": "../../packages/firestore-plugin" }
   ]
 }

--- a/packages/core/src/store.ts
+++ b/packages/core/src/store.ts
@@ -134,7 +134,7 @@ export const createStore = <State>(
     completeEvent(event, store);
     plugins.forEach(p => {
       if (p.onCompletedEvent) {
-        p.onCompletedEvent(event);
+        p.onCompletedEvent(event, config);
       }
     });
   };

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -49,7 +49,7 @@ interface ProdoPluginSpec<InitOptions, Universe, ActionCtx, ViewCtx> {
     },
     config: InitOptions,
   ) => void;
-  onCompletedEvent?: (event: Event) => void;
+  onCompletedEvent?: (event: Event, config: InitOptions) => void;
   Provider?: Provider;
 }
 

--- a/packages/logger-plugin/src/index.tsx
+++ b/packages/logger-plugin/src/index.tsx
@@ -6,7 +6,7 @@ export interface LoggerConfig {
 
 const init = (config: LoggerConfig) => {
   if (config.logger) {
-    // tslint:disable-next-line
+    // tslint:disable-next-line:no-console
     console.log("@prodo/logger is on");
   }
 };
@@ -14,9 +14,11 @@ const init = (config: LoggerConfig) => {
 const loggerPlugin: ProdoPlugin<LoggerConfig, {}, {}, {}> = {
   name: "logger",
   init,
-  onCompletedEvent: e => {
-    // tslint:disable-next-line
-    console.log(e);
+  onCompletedEvent: (e, config) => {
+    if (config.logger) {
+      // tslint:disable-next-line:no-console
+      console.log(e);
+    }
   },
 };
 

--- a/packages/route-plugin/src/index.ts
+++ b/packages/route-plugin/src/index.ts
@@ -69,3 +69,4 @@ export default routingPlugin;
 export { push, replace } from "./actions";
 export { Config, RouteParams } from "./types";
 export { Route, Switch, Link, Redirect } from "./react";
+export { matchRoute } from "./utils";

--- a/packages/route-plugin/src/react.tsx
+++ b/packages/route-plugin/src/react.tsx
@@ -1,62 +1,8 @@
 import { connect } from "@prodo/core";
-import * as pathToRegexp from "path-to-regexp";
 import * as React from "react";
 import * as actions from "./actions";
 import { RouteParams } from "./types";
-import { createParamString } from "./utils";
-
-const cache = {};
-const cacheLimit = 1000;
-let cacheCount = 0;
-
-const compilePattern = (
-  pattern: string,
-  options: pathToRegexp.RegExpOptions,
-) => {
-  const optionKey = `${options.end}.${options.strict}.${options.sensitive}`;
-  const optionCache = cache[optionKey] || (cache[optionKey] = {});
-
-  if (optionCache[pattern]) {
-    return optionCache[pattern];
-  }
-
-  const keys = [];
-  const regex = pathToRegexp(pattern, keys, options);
-  const result = { keys, regex };
-
-  if (cacheCount < cacheLimit) {
-    optionCache[pattern] = result;
-    cacheCount++;
-  }
-
-  return result;
-};
-
-const routeMatches = (
-  path: string,
-  pattern: string,
-  exact: boolean = false,
-) => {
-  const options = { end: exact, strict: false, sensitive: false };
-  const { regex, keys } = compilePattern(pattern, options);
-
-  const match = regex.exec(path);
-  if (match == null) {
-    return null;
-  }
-
-  const [url, ...values] = match;
-  const isExact = url === path;
-
-  if (exact && !isExact) {
-    return null;
-  }
-
-  return keys.reduce(
-    (acc, key, index) => ({ ...acc, [key.name]: values[index] }),
-    {},
-  );
-};
+import { createParamString, matchRoute } from "./utils";
 
 export interface RouteProps {
   path?: string;
@@ -73,7 +19,7 @@ export const Route = connect(
     component,
   }: RouteProps): React.ReactElement | null => {
     const match =
-      path == null ? {} : routeMatches(watch(route.path), path, exact);
+      path == null ? {} : matchRoute(watch(route.path), path, exact);
     if (match != null) {
       if (children && React.Children.count(children) > 0) {
         return <>{children}</>;
@@ -92,7 +38,7 @@ export const Switch = connect(
       if (element == null && React.isValidElement(child)) {
         const path = child.props.path;
         if (path != null) {
-          if (routeMatches(watch(route.path), path, child.props.exact)) {
+          if (matchRoute(watch(route.path), path, child.props.exact)) {
             element = child;
           }
         } else {

--- a/packages/route-plugin/src/react.tsx
+++ b/packages/route-plugin/src/react.tsx
@@ -88,7 +88,7 @@ const Anchor = ({ onClick, navigate, ...rest }: any) => (
       if (
         !e.defaultPrevented &&
         e.button === 0 &&
-        (rest.target || rest.target === "_self") &&
+        (!rest.target || rest.target === "_self") &&
         !e.metaKey &&
         !e.altKey &&
         !e.ctrlKey &&

--- a/packages/route-plugin/src/utils.ts
+++ b/packages/route-plugin/src/utils.ts
@@ -1,3 +1,58 @@
+import * as pathToRegexp from "path-to-regexp";
+
+const cache = {};
+const cacheLimit = 1000;
+let cacheCount = 0;
+
+const compilePattern = (
+  pattern: string,
+  options: pathToRegexp.RegExpOptions,
+) => {
+  const optionKey = `${options.end}.${options.strict}.${options.sensitive}`;
+  const optionCache = cache[optionKey] || (cache[optionKey] = {});
+
+  if (optionCache[pattern]) {
+    return optionCache[pattern];
+  }
+
+  const keys = [];
+  const regex = pathToRegexp(pattern, keys, options);
+  const result = { keys, regex };
+
+  if (cacheCount < cacheLimit) {
+    optionCache[pattern] = result;
+    cacheCount++;
+  }
+
+  return result;
+};
+
+export const matchRoute = (
+  path: string,
+  pattern: string,
+  exact: boolean = false,
+) => {
+  const options = { end: exact, strict: false, sensitive: false };
+  const { regex, keys } = compilePattern(pattern, options);
+
+  const match = regex.exec(path);
+  if (match == null) {
+    return null;
+  }
+
+  const [url, ...values] = match;
+  const isExact = url === path;
+
+  if (exact && !isExact) {
+    return null;
+  }
+
+  return keys.reduce(
+    (acc, key, index) => ({ ...acc, [key.name]: values[index] }),
+    {},
+  );
+};
+
 export const createParamString = (params?: { [key: string]: string }) => {
   if (params == null) {
     return "";

--- a/packages/route-plugin/tests/index.test.ts
+++ b/packages/route-plugin/tests/index.test.ts
@@ -4,7 +4,7 @@ import routePlugin, { push, replace } from "../src";
 
 const model = createModel<{}>().with(routePlugin);
 
-describe("random plugin", () => {
+describe("route plugin", () => {
   it("", async () => {
     const history = createMemoryHistory();
 

--- a/packages/route-plugin/tests/utils.test.ts
+++ b/packages/route-plugin/tests/utils.test.ts
@@ -1,0 +1,25 @@
+import { matchRoute } from "../src";
+
+describe("matchRoute", () => {
+  it("can match a route", () => {
+    expect(matchRoute("/a/b/c", "/a/b/c")).toBeTruthy();
+    expect(matchRoute("/a/b/c", "/a/b/d")).toBeFalsy();
+  });
+
+  it("can partially match a route", () => {
+    expect(matchRoute("/a/b/c", "/a/b")).toBeTruthy();
+  });
+
+  it("can exactly match a route", () => {
+    expect(matchRoute("/a/b/c", "/a/b/c", true)).toBeTruthy();
+    expect(matchRoute("/a/b/c", "/a/b/d", true)).toBeFalsy();
+    expect(matchRoute("/a/b/c", "/a/b", true)).toBeFalsy();
+  });
+
+  it("can extract params from a match", () => {
+    const match = matchRoute("/a/b/c", "/a/:prop1/:prop2");
+    expect(match).toBeTruthy();
+    expect(match.prop1).toBe("b");
+    expect(match.prop2).toBe("c");
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -3094,23 +3094,6 @@
     "@types/react" "*"
     "@types/react-icon-base" "*"
 
-"@types/react-router-dom@^4.3.5":
-  version "4.3.5"
-  resolved "https://registry.yarnpkg.com/@types/react-router-dom/-/react-router-dom-4.3.5.tgz#72f229967690c890d00f96e6b85e9ee5780db31f"
-  integrity sha512-eFajSUASYbPHg2BDM1G8Btx+YqGgvROPIg6sBhl3O4kbDdYXdFdfrgQFf/pcBuQVObjfT9AL/dd15jilR5DIEA==
-  dependencies:
-    "@types/history" "*"
-    "@types/react" "*"
-    "@types/react-router" "*"
-
-"@types/react-router@*":
-  version "5.0.3"
-  resolved "https://registry.yarnpkg.com/@types/react-router/-/react-router-5.0.3.tgz#855a1606e62de3f4d69ea34fb3c0e50e98e964d5"
-  integrity sha512-j2Gge5cvxca+5lK9wxovmGPgpVJMwjyu5lTA/Cd6fLGoPq7FXcUE1jFkEdxeyqGGz8VfHYSHCn5Lcn24BzaNKA==
-  dependencies:
-    "@types/history" "*"
-    "@types/react" "*"
-
 "@types/react-textarea-autosize@^4.3.4":
   version "4.3.4"
   resolved "https://registry.yarnpkg.com/@types/react-textarea-autosize/-/react-textarea-autosize-4.3.4.tgz#9a93f751c91ad5e86387bce75e3b7e11ed195813"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2752,20 +2752,6 @@
     string-width "^2.0.0"
     strip-ansi "^3"
 
-"@prodo/core@^0.0.1":
-  version "0.0.1"
-  resolved "https://registry.yarnpkg.com/@prodo/core/-/core-0.0.1.tgz#932f935782ea630654b55490d895c64365a82884"
-  integrity sha512-thxKuoy7FRxKm8XIzb/Ho8yZ6xppHF/XAQPeFrBw15rxn2NPBql8vQwQHNF6Oq96eQh8MXawAucXojlmArWjLQ==
-  dependencies:
-    immer "^3.2.0"
-    react "^16.9.0"
-    react-dom "^16.9.0"
-
-"@prodo/effect@^0.0.1":
-  version "0.0.1"
-  resolved "https://registry.yarnpkg.com/@prodo/effect/-/effect-0.0.1.tgz#a977f28107ac9791632e68e2c1832cd6d38b3a7c"
-  integrity sha512-9lSWEFZfyaVmnPMWvQfWXdLKykgQUr7vElPr/VRsNm+mliGxTN+i8ZZesIzmWE1IwslesI23f7NpP7Aj0q/yhQ==
-
 "@protobufjs/aspromise@^1.1.1", "@protobufjs/aspromise@^1.1.2":
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/@protobufjs/aspromise/-/aspromise-1.1.2.tgz#9b8b0cc663d669a7d8f6f5d0893a14d348f30fbf"
@@ -10345,6 +10331,18 @@ hex-color-regex@^1.1.0:
   resolved "https://registry.yarnpkg.com/hex-color-regex/-/hex-color-regex-1.1.0.tgz#4c06fccb4602fe2602b3c93df82d7e7dbf1a8a8e"
   integrity sha512-l9sfDFsuqtOqKDsQdqrMRk0U85RZc0RtOR9yPI7mRVOa4FsR/BVnZ0shmQRM96Ji99kYZP/7hn1cedc1+ApsTQ==
 
+history@^4.10.1:
+  version "4.10.1"
+  resolved "https://registry.yarnpkg.com/history/-/history-4.10.1.tgz#33371a65e3a83b267434e2b3f3b1b4c58aad4cf3"
+  integrity sha512-36nwAD620w12kuzPAsyINPWJqlNbij+hpK1k9XRloDtym8mxzGYl2c17LnV6IAGB2Dmg4tEa7G7DlawS0+qjew==
+  dependencies:
+    "@babel/runtime" "^7.1.2"
+    loose-envify "^1.2.0"
+    resolve-pathname "^3.0.0"
+    tiny-invariant "^1.0.2"
+    tiny-warning "^1.0.0"
+    value-equal "^1.0.1"
+
 history@^4.9.0:
   version "4.9.0"
   resolved "https://registry.yarnpkg.com/history/-/history-4.9.0.tgz#84587c2068039ead8af769e9d6a6860a14fa1bca"
@@ -16796,6 +16794,11 @@ resolve-pathname@^2.2.0:
   resolved "https://registry.yarnpkg.com/resolve-pathname/-/resolve-pathname-2.2.0.tgz#7e9ae21ed815fd63ab189adeee64dc831eefa879"
   integrity sha512-bAFz9ld18RzJfddgrO2e/0S2O81710++chRMUxHjXOYKF6jTAMrUNZrEZ1PvV0zlhfjidm08iRPdTLPno1FuRg==
 
+resolve-pathname@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/resolve-pathname/-/resolve-pathname-3.0.0.tgz#99d02224d3cf263689becbb393bc560313025dcd"
+  integrity sha512-C7rARubxI8bXFNB/hqcp/4iUeIXJhJZvFPFPiSPRnhU5UPxzMFIl+2E6yY6c4k9giDJAhtV+enfA+G89N6Csng==
+
 resolve-url@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/resolve-url/-/resolve-url-0.2.1.tgz#2c637fe77c893afd2a663fe21aa9080068e2052a"
@@ -19457,6 +19460,11 @@ value-equal@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/value-equal/-/value-equal-0.4.0.tgz#c5bdd2f54ee093c04839d71ce2e4758a6890abc7"
   integrity sha512-x+cYdNnaA3CxvMaTX0INdTCN8m8aF2uY9BvEqmxuYp8bL09cs/kWVQPVGcA35fMktdOsP69IgU7wFj/61dJHEw==
+
+value-equal@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/value-equal/-/value-equal-1.0.1.tgz#1e0b794c734c5c0cade179c437d356d931a34d6c"
+  integrity sha512-NOJ6JZCAWr0zlxZt+xqCHNTEKOsrks2HQd4MqhP1qy4z1SkbEP467eNx6TgDKXMvUOb+OENfJCZwM+16n7fRfw==
 
 vary@^1, vary@~1.1.2:
   version "1.1.2"


### PR DESCRIPTION
Sorry about all the linting changes - my IDE applied them automatically.

This is identical to https://github.com/prodo-ai/prodo-kanban/pull/1/files except that it adds a new utility to `@prodo/route`, `matchRoute` that matches a route to a slug and extracts the params:

```js
const path = "/a/b/c"
const pattern = "/a/:prop1/:prop2"
const match = matchRoute(path, pattern); // equals {prop1: "b", prop2: "c"};
```

(see tests [here](https://github.com/prodo-ai/prodo/pull/76/files#diff-20af078721e94f3cb940443bf425b850) for examples)

and uses this instead of passing the `boardId` as a prop (see [here](https://github.com/prodo-ai/prodo/pull/76/files#diff-c27b887cfa00553d0817dc200f0dc749R17) for an example).