### PR TITLE
Make stream plugin private

### DIFF
--- a/packages/stream-plugin/package.json
+++ b/packages/stream-plugin/package.json
@@ -3,6 +3,7 @@
   "version": "0.0.5",
   "main": "lib/index.js",
   "license": "MIT",
+  "private": true,
   "files": [
     "lib",
     "src"


### PR DESCRIPTION
I thought it already was. Not sure if we should be publishing this when it doesn't work with the transpiler.

https://github.com/prodo-ai/prodo/issues/66