### PR TITLE
Merge stream changes from KDB branch

### DIFF
--- a/packages/stream-plugin/src/index.ts
+++ b/packages/stream-plugin/src/index.ts
@@ -26,7 +26,7 @@ export interface Universe<T extends { [K in keyof T]: Stream<any> }> {
 }
 
 interface State<T extends { [K in keyof T]: Stream<any> }> {
-  streams: T;
+  streams: Partial<T>;
   states: { [K in keyof T]?: StreamState };
 }
 
@@ -95,7 +95,7 @@ const streamPlugin = <T extends { [K in keyof T]: Stream<any> }>(): ProdoPlugin<
   ViewCtx<T>
 > => {
   const state: State<T> = {
-    streams: {} as any,
+    streams: {},
     states: {},
   };
 

--- a/packages/stream-plugin/src/index.ts
+++ b/packages/stream-plugin/src/index.ts
@@ -16,38 +16,38 @@ export interface Stream<T> {
   subscribe: (cb: (value: T) => void) => StreamState;
 }
 
-type UnStreams<T extends { [K in keyof T]?: Stream<any> }> = {
-  [K in keyof T]?: T[K] extends Stream<infer V> ? V : never;
+export type UnStreams<T extends { [K in keyof T]: Stream<any> }> = {
+  [K in keyof T]: T[K] extends Stream<infer V> ? V : never
 };
 
 // Stores the latest values
-export interface Universe<T extends { [K in keyof T]?: Stream<any> }> {
-  streams: UnStreams<T>;
+export interface Universe<T extends { [K in keyof T]: Stream<any> }> {
+  streams: Partial<UnStreams<T>>;
 }
 
-interface State<T extends { [K in keyof T]?: Stream<any> }> {
+interface State<T extends { [K in keyof T]: Stream<any> }> {
   streams: T;
   states: { [K in keyof T]?: StreamState };
 }
 
-export interface ViewCtx<T extends { [K in keyof T]?: Stream<any> }> {
-  streams: UnStreams<T>;
+export interface ViewCtx<T extends { [K in keyof T]: Stream<any> }> {
+  streams: Partial<UnStreams<T>>;
 }
 
-export interface ActionCtx<T extends { [K in keyof T]?: Stream<any> }> {
-  streams: T;
+export interface ActionCtx<T extends { [K in keyof T]: Stream<any> }> {
+  streams: Partial<T>;
   // Private to streamUpdate
-  [valueSymbol]: UnStreams<T>;
+  [valueSymbol]: Partial<UnStreams<T>>;
 }
 
-const init = <T extends { [K in keyof T]?: Stream<any> }>(
+const init = <T extends { [K in keyof T]: Stream<any> }>(
   _config: {},
   universe: Universe<T>,
 ) => {
   universe.streams = {};
 };
 
-const prepareActionCtx = <T extends { [K in keyof T]?: Stream<any> }>(
+const prepareActionCtx = <T extends { [K in keyof T]: Stream<any> }>(
   state: State<T>,
   streamUpdate: PluginAction<ActionCtx<T>, [keyof T, any]>,
 ) => ({
@@ -80,7 +80,7 @@ const prepareActionCtx = <T extends { [K in keyof T]?: Stream<any> }>(
   });
 };
 
-const prepareViewCtx = <T extends { [K in keyof T]?: Stream<any> }>({
+const prepareViewCtx = <T extends { [K in keyof T]: Stream<any> }>({
   ctx,
 }: {
   ctx: ViewCtx<T>;
@@ -88,9 +88,12 @@ const prepareViewCtx = <T extends { [K in keyof T]?: Stream<any> }>({
   ctx.streams = createUniverseWatcher("streams");
 };
 
-const streamPlugin = <
-  T extends { [K in keyof T]?: Stream<any> }
->(): ProdoPlugin<{}, Universe<T>, ActionCtx<T>, ViewCtx<T>> => {
+const streamPlugin = <T extends { [K in keyof T]: Stream<any> }>(): ProdoPlugin<
+  {},
+  Universe<T>,
+  ActionCtx<T>,
+  ViewCtx<T>
+> => {
   const state: State<T> = {
     streams: {} as any,
     states: {},

--- a/packages/stream-plugin/src/index.ts
+++ b/packages/stream-plugin/src/index.ts
@@ -16,8 +16,12 @@ export interface Stream<T> {
   subscribe: (cb: (value: T) => void) => StreamState;
 }
 
+export type UnStream<T extends Stream<any>> = T extends Stream<infer V>
+  ? V
+  : never;
+
 export type UnStreams<T extends { [K in keyof T]: Stream<any> }> = {
-  [K in keyof T]: T[K] extends Stream<infer V> ? V : never
+  [K in keyof T]: UnStream<T[K]>;
 };
 
 // Stores the latest values


### PR DESCRIPTION
The `Streams` type is now complete, and the transform to `Partial<Streams>` is done in `prepareViewCtx`. This makes the user type easier to work with in generics (no need to `Required` it everywhere), and also makes it clear that there is (currently) no way to have an always-defined stream value.