### PR TITLE
Fix core js warning

### DIFF
--- a/examples/chat-app/.babelrc
+++ b/examples/chat-app/.babelrc
@@ -2,7 +2,7 @@
   "presets": [
     "@babel/preset-typescript",
     "@babel/preset-react",
-    ["@babel/preset-env", { "useBuiltIns": "usage" }]
+    ["@babel/preset-env", { "useBuiltIns": "usage", "corejs": 2 }]
   ],
   "plugins": ["@prodo/babel-plugin"],
   "sourceMaps": "both"

--- a/examples/chat-app/package.json
+++ b/examples/chat-app/package.json
@@ -12,6 +12,7 @@
     "@prodo/core": "^0.0.7",
     "@prodo/firestore": "^0.0.7",
     "@prodo/logger": "^0.0.7",
+    "core-js": "2",
     "moment": "^2.24.0",
     "react": "^16.8.6",
     "react-dom": "^16.9.0"

--- a/examples/clock/.babelrc
+++ b/examples/clock/.babelrc
@@ -2,7 +2,7 @@
   "presets": [
     "@babel/preset-typescript",
     "@babel/preset-react",
-    ["@babel/preset-env", { "useBuiltIns": "usage" }]
+    ["@babel/preset-env", { "useBuiltIns": "usage", "corejs": 2 }]
   ],
   "sourceMaps": "both"
 }

--- a/examples/clock/package.json
+++ b/examples/clock/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "@prodo/core": "^0.0.7",
+    "core-js": "2",
     "react": "^16.8.6",
     "react-dom": "^16.9.0"
   },

--- a/examples/kanban-with-db/.babelrc
+++ b/examples/kanban-with-db/.babelrc
@@ -2,7 +2,7 @@
   "presets": [
     "@babel/preset-typescript",
     "@babel/preset-react",
-    "@babel/preset-env"
+    ["@babel/preset-env", { "useBuiltIns": "usage", "corejs": 2 }]
   ],
   "plugins": ["@babel/proposal-class-properties", "@prodo/babel-plugin"],
   "sourceMaps": "both"

--- a/examples/kanban-with-db/package.json
+++ b/examples/kanban-with-db/package.json
@@ -14,6 +14,7 @@
     "@prodo/firestore": "^0.0.7",
     "@prodo/logger": "^0.0.7",
     "classnames": "^2.2.5",
+    "core-js": "2",
     "date-fns": "^1.29.0",
     "marked": "^0.3.19",
     "react": "^16.8.6",

--- a/examples/kanban/.babelrc
+++ b/examples/kanban/.babelrc
@@ -2,7 +2,7 @@
   "presets": [
     "@babel/preset-typescript",
     "@babel/preset-react",
-    ["@babel/preset-env", { "useBuiltIns": "usage" }]
+    ["@babel/preset-env", { "useBuiltIns": "usage", "corejs": 2 }]
   ],
   "plugins": ["@babel/proposal-class-properties", "@prodo/babel-plugin"],
   "sourceMaps": "both"

--- a/examples/kanban/package.json
+++ b/examples/kanban/package.json
@@ -16,6 +16,7 @@
     "@prodo/logger": "^0.0.7",
     "@prodo/route": "^0.0.7",
     "classnames": "^2.2.5",
+    "core-js": "2",
     "date-fns": "^1.29.0",
     "history": "^4.10.1",
     "marked": "^0.3.19",

--- a/examples/local-map/.babelrc
+++ b/examples/local-map/.babelrc
@@ -2,7 +2,7 @@
   "presets": [
     "@babel/preset-typescript",
     "@babel/preset-react",
-    ["@babel/preset-env", { "useBuiltIns": "usage" }]
+    ["@babel/preset-env", { "useBuiltIns": "usage", "corejs": 2 }]
   ],
   "plugins": ["@prodo/babel-plugin"],
   "sourceMaps": "both"

--- a/examples/local-map/package.json
+++ b/examples/local-map/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "@prodo/core": "^0.0.7",
     "@prodo/local": "^0.0.7",
+    "core-js": "2",
     "pigeon-maps": "^0.13.0",
     "pigeon-marker": "^0.3.4",
     "pigeon-overlay": "^0.2.3",

--- a/examples/random/.babelrc
+++ b/examples/random/.babelrc
@@ -2,7 +2,7 @@
   "presets": [
     "@babel/preset-typescript",
     "@babel/preset-react",
-    ["@babel/preset-env", { "useBuiltIns": "usage" }]
+    ["@babel/preset-env", { "useBuiltIns": "usage", "corejs": 2 }]
   ],
   "sourceMaps": "both"
 }

--- a/examples/random/package.json
+++ b/examples/random/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "@prodo/core": "^0.0.7",
     "@prodo/random": "^0.0.7",
+    "core-js": "2",
     "react": "^16.8.6",
     "react-dom": "^16.9.0"
   },

--- a/examples/routing/.babelrc
+++ b/examples/routing/.babelrc
@@ -2,7 +2,7 @@
   "presets": [
     "@babel/preset-typescript",
     "@babel/preset-react",
-    ["@babel/preset-env", { "useBuiltIns": "usage" }]
+    ["@babel/preset-env", { "useBuiltIns": "usage", "corejs": 2 }]
   ],
   "sourceMaps": "both"
 }

--- a/examples/routing/package.json
+++ b/examples/routing/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "@prodo/core": "^0.0.7",
     "@prodo/route": "^0.0.7",
+    "core-js": "2",
     "history": "^4.9.0",
     "react": "^16.8.6",
     "react-dom": "^16.9.0",

--- a/examples/timers/.babelrc
+++ b/examples/timers/.babelrc
@@ -2,7 +2,7 @@
   "presets": [
     "@babel/preset-typescript",
     "@babel/preset-react",
-    ["@babel/preset-env", { "useBuiltIns": "usage" }]
+    ["@babel/preset-env", { "useBuiltIns": "usage", "corejs": 2 }]
   ],
   "sourceMaps": "both"
 }

--- a/examples/timers/package.json
+++ b/examples/timers/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "@prodo/core": "^0.0.7",
     "@prodo/stream": "^0.0.7",
+    "core-js": "2",
     "react": "^16.8.6",
     "react-dom": "^16.9.0",
     "rxjs": "^6.5.2"

--- a/examples/todo-app/.babelrc
+++ b/examples/todo-app/.babelrc
@@ -2,7 +2,7 @@
   "presets": [
     "@babel/preset-typescript",
     "@babel/preset-react",
-    ["@babel/preset-env", { "useBuiltIns": "usage" }]
+    ["@babel/preset-env", { "useBuiltIns": "usage", "corejs": 2 }]
   ],
   "plugins": ["@prodo/babel-plugin"],
   "sourceMaps": "both"

--- a/examples/todo-app/package.json
+++ b/examples/todo-app/package.json
@@ -19,6 +19,9 @@
   },
   "devDependencies": {
     "@babel/core": "^7.6.0",
+    "@babel/preset-env": "^7.6.0",
+    "@babel/preset-react": "^7.0.0",
+    "@babel/preset-typescript": "^7.6.0",
     "@prodo/babel-plugin": "^0.0.7",
     "@testing-library/react": "^9.1.3",
     "@types/jest": "^24.0.18",

--- a/examples/todo-app/package.json
+++ b/examples/todo-app/package.json
@@ -14,6 +14,7 @@
     "@prodo/devtools-plugin": "^0.0.7",
     "@prodo/effect": "^0.0.7",
     "@prodo/logger": "^0.0.7",
+    "core-js": "2",
     "react": "^16.8.6",
     "react-dom": "^16.9.0"
   },

--- a/examples/transpilation/.babelrc
+++ b/examples/transpilation/.babelrc
@@ -2,7 +2,7 @@
   "presets": [
     "@babel/preset-typescript",
     "@babel/preset-react",
-    ["@babel/preset-env", { "useBuiltIns": "usage" }]
+    ["@babel/preset-env", { "useBuiltIns": "usage", "corejs": 2 }]
   ],
   "plugins": ["@prodo/babel-plugin"],
   "sourceMaps": "both"

--- a/examples/transpilation/package.json
+++ b/examples/transpilation/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "@prodo/core": "^0.0.7",
+    "core-js": "2",
     "react": "^16.8.6",
     "react-dom": "^16.9.0"
   },

--- a/examples/update-testing/.babelrc
+++ b/examples/update-testing/.babelrc
@@ -2,7 +2,7 @@
   "presets": [
     "@babel/preset-typescript",
     "@babel/preset-react",
-    ["@babel/preset-env", { "useBuiltIns": "usage" }]
+    ["@babel/preset-env", { "useBuiltIns": "usage", "corejs": 2 }]
   ],
   "sourceMaps": "both"
 }

--- a/examples/update-testing/package.json
+++ b/examples/update-testing/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "@prodo/core": "^0.0.7",
+    "core-js": "2",
     "react": "^16.8.6",
     "react-dom": "^16.9.0"
   },


### PR DESCRIPTION
- Add core-js to all examples `.babelrc` and `package.json`
- Add readme to kanban app example

Address this

```
WARNING: We noticed you're using the `useBuiltIns` option without declaring a
core-js version. Currently, we assume version 2.x when no version is passed.
Since this default version will likely change in future versions of Babel, we
recommend explicitly setting the core-js version you are using via the `corejs`
option.

You should also be sure that the version you pass to the `corejs` option matches
the version specified in your `package.json`'s `dependencies` section. If it
doesn't, you need to run one of the following commands:

  npm install --save core-js@2    npm install --save core-js@3
  yarn add core-js@2              yarn add core-js@3
```