### PR TITLE
Devtools - Add a button to clear action and render logs

### DIFF
--- a/examples/kanban/src/store.tsx
+++ b/examples/kanban/src/store.tsx
@@ -4,7 +4,7 @@ import { model } from "./model";
 const history = createBrowserHistory();
 
 export const { store, Provider } = model.createStore({
-  devtools: false,
+  devtools: true,
   logger: true,
   initState: {
     user: {

--- a/packages/devtools-core/src/App/DevTools/ActionLogPanel/index.tsx
+++ b/packages/devtools-core/src/App/DevTools/ActionLogPanel/index.tsx
@@ -1,20 +1,35 @@
 import * as React from "react";
+import styled from "styled-components";
 import { state, watch } from "../../../model";
 import { Action } from "../../../types";
+import { ClearLogsButton } from "../components/ClearLogsButton";
 import { ActionLogRow } from "./ActionLogRow";
 
 export const emptyActionLogMessage = "Action log is empty.";
+
+const StyledActionLogPanel = styled.div`
+  display: flex;
+  flex-direction: column;
+`;
 
 export const ActionLogPanel = () => {
   const actions = watch(state.app.actionLog);
 
   return (
-    <div className="actionLogPanel" data-testid="actionLogPanel">
-      {actions.length === 0
-        ? emptyActionLogMessage
-        : actions.map((action: Action, index: number) => (
+    <StyledActionLogPanel
+      className="actionLogPanel"
+      data-testid="actionLogPanel"
+    >
+      {actions.length === 0 ? (
+        emptyActionLogMessage
+      ) : (
+        <>
+          {actions.map((action: Action, index: number) => (
             <ActionLogRow action={action} key={index} />
           ))}
-    </div>
+          <ClearLogsButton />
+        </>
+      )}
+    </StyledActionLogPanel>
   );
 };

--- a/packages/devtools-core/src/App/DevTools/RenderLogPanel/index.tsx
+++ b/packages/devtools-core/src/App/DevTools/RenderLogPanel/index.tsx
@@ -1,15 +1,23 @@
 import * as _ from "lodash";
 import * as React from "react";
+import styled from "styled-components";
 import { state, watch } from "../../../model";
+import { Render } from "../../../types";
+import { ClearLogsButton } from "../components/ClearLogsButton";
 import { RenderLogRow } from "./RenderLogRow";
 
 export const emptyRenderLogMessage = "Render log is empty.";
+
+const StyledRenderLogPanel = styled.div`
+  display: flex;
+  flex-direction: column;
+`;
 
 export const RenderLogPanel = () => {
   const renderLog = watch(state.app.renderLog);
 
   const components = {};
-  renderLog.map(entry => {
+  renderLog.map((entry: Render) => {
     if (!components[entry.componentId]) {
       components[entry.componentId] = { total: 1 };
       components[entry.componentId][entry.actionName] = 1;
@@ -24,7 +32,10 @@ export const RenderLogPanel = () => {
   });
 
   return (
-    <div className="renderLogPanel" data-testid="renderLogPanel">
+    <StyledRenderLogPanel
+      className="renderLogPanel"
+      data-testid="renderLogPanel"
+    >
       {renderLog.length === 0
         ? emptyRenderLogMessage
         : Object.keys(components).map((componentId: string, index: number) => (
@@ -34,6 +45,7 @@ export const RenderLogPanel = () => {
               key={index}
             />
           ))}
-    </div>
+      {renderLog.length > 0 && <ClearLogsButton />}
+    </StyledRenderLogPanel>
   );
 };

--- a/packages/devtools-core/src/App/DevTools/components/ClearLogsButton.tsx
+++ b/packages/devtools-core/src/App/DevTools/components/ClearLogsButton.tsx
@@ -1,0 +1,36 @@
+import * as React from "react";
+import styled from "styled-components";
+import { dispatch, state } from "../../../model";
+import { margins, paddings } from "../../../styles";
+
+export const clearLogs = () => {
+  state.app.actionLog = [];
+  state.app.renderLog = [];
+};
+
+const StyledButton = styled.button`
+  padding: ${paddings.small};
+  margin: ${margins.small};
+  background-color: ${props => props.theme.colors.bg};
+  color: ${props => props.theme.colors.fg}
+  border: white solid 1px;
+  border-radius: 4px;
+
+  cursor: pointer;
+  &:hover {
+    color: ${props => props.theme.colors.accent};
+  }
+
+  width: 100px;
+  align-self: end;
+`;
+
+export const ClearLogsButton = () => (
+  <StyledButton
+    onClick={() => dispatch(clearLogs)()}
+    className="clearLogsButton"
+    data-testid="clearLogsButton"
+  >
+    Clear logs
+  </StyledButton>
+);

--- a/packages/devtools-core/tests/actions/index.test.ts
+++ b/packages/devtools-core/tests/actions/index.test.ts
@@ -1,10 +1,11 @@
+import { clearLogs } from "../../src/App/DevTools/components/ClearLogsButton";
 import { model } from "../../src/model";
 import { initState } from "../../src/store";
 import { Action } from "../../src/types";
 import { recordAction, recordState } from "../../src/utils/communication";
 
 import "@babel/polyfill";
-import { testActionLog, testAppState } from "../fixtures";
+import { populatedState, testActionLog, testAppState } from "../fixtures";
 
 describe("actions", () => {
   it("records state", async () => {
@@ -30,5 +31,15 @@ describe("actions", () => {
     const { state } = await store.dispatch(recordAction)(action);
     expect(state.app.actionLog.length).toBe(1);
     expect(state.app.actionLog[0].actionName).toBe(testActionLog[0].actionName);
+  });
+
+  it("clears action and render lgos", async () => {
+    const { store } = model.createStore({
+      initState: populatedState,
+    });
+
+    const { state } = await store.dispatch(clearLogs)();
+    expect(state.app.actionLog.length).toBe(0);
+    expect(state.app.renderLog.length).toBe(0);
   });
 });

--- a/packages/devtools-core/tests/actions/index.test.ts
+++ b/packages/devtools-core/tests/actions/index.test.ts
@@ -4,7 +4,6 @@ import { initState } from "../../src/store";
 import { Action } from "../../src/types";
 import { recordAction, recordState } from "../../src/utils/communication";
 
-import "@babel/polyfill";
 import { populatedState, testActionLog, testAppState } from "../fixtures";
 
 describe("actions", () => {
@@ -33,11 +32,12 @@ describe("actions", () => {
     expect(state.app.actionLog[0].actionName).toBe(testActionLog[0].actionName);
   });
 
-  it("clears action and render lgos", async () => {
+  it("clears action and render logs", async () => {
     const { store } = model.createStore({
       initState: populatedState,
     });
 
+    expect(store.universe.state.app.actionLog.length).toBeGreaterThan(0);
     const { state } = await store.dispatch(clearLogs)();
     expect(state.app.actionLog.length).toBe(0);
     expect(state.app.renderLog.length).toBe(0);

--- a/packages/devtools-core/tests/components/DevTools/ActionLogPanel/ActionLogRow.test.tsx
+++ b/packages/devtools-core/tests/components/DevTools/ActionLogPanel/ActionLogRow.test.tsx
@@ -1,4 +1,3 @@
-import "@babel/polyfill";
 import { fireEvent } from "@testing-library/react";
 import * as React from "react";
 import { ActionLogRow } from "../../../../src/App/DevTools/ActionLogPanel/ActionLogRow";

--- a/packages/devtools-core/tests/components/DevTools/ActionLogPanel/index.test.tsx
+++ b/packages/devtools-core/tests/components/DevTools/ActionLogPanel/index.test.tsx
@@ -1,4 +1,3 @@
-import "@babel/polyfill";
 import * as React from "react";
 import {
   ActionLogPanel,

--- a/packages/devtools-core/tests/components/DevTools/RenderLogPanel/index.test.tsx
+++ b/packages/devtools-core/tests/components/DevTools/RenderLogPanel/index.test.tsx
@@ -1,4 +1,3 @@
-import "@babel/polyfill";
 import * as _ from "lodash";
 import * as React from "react";
 import {

--- a/packages/devtools-core/tests/components/DevTools/RenderLogPanel/index.test.tsx
+++ b/packages/devtools-core/tests/components/DevTools/RenderLogPanel/index.test.tsx
@@ -1,36 +1,40 @@
 import "@babel/polyfill";
+import * as _ from "lodash";
 import * as React from "react";
 import {
-  ActionLogPanel,
-  emptyActionLogMessage,
-} from "../../../../src/App/DevTools/ActionLogPanel";
+  emptyRenderLogMessage,
+  RenderLogPanel,
+} from "../../../../src/App/DevTools/RenderLogPanel";
 import { model } from "../../../../src/model";
 import { initState } from "../../../../src/store";
 import { populatedState } from "../../../fixtures";
 import { renderWithProdo } from "../../../utils";
 
-describe("ActionLogPanel", () => {
-  it("is empty when there is no actions", async () => {
+describe("RenderLogPanel", () => {
+  it("is empty when there is no renders", async () => {
     const { getByTestId, queryByTestId } = renderWithProdo(
-      <ActionLogPanel />,
+      <RenderLogPanel />,
       model.createStore({ initState }),
     );
 
-    expect(getByTestId("actionLogPanel").textContent).toBe(
-      emptyActionLogMessage,
+    expect(getByTestId("renderLogPanel").textContent).toBe(
+      emptyRenderLogMessage,
     );
 
     expect(queryByTestId("clearLogsButton")).toBeNull();
   });
 
-  it("renders all actions in the log", async () => {
+  it("renders all renders in the log", async () => {
     const { findAllByTestId, getByTestId } = renderWithProdo(
-      <ActionLogPanel />,
+      <RenderLogPanel />,
       model.createStore({ initState: populatedState }),
     );
 
-    expect(await findAllByTestId("actionLogRow")).toHaveLength(
-      populatedState.app.actionLog.length,
+    const components = _.uniq(
+      populatedState.app.renderLog.map(entry => entry.componentId),
+    );
+    expect(await findAllByTestId("renderLogRow")).toHaveLength(
+      components.length,
     );
 
     expect(getByTestId("clearLogsButton")).toBeTruthy;

--- a/packages/devtools-core/tests/components/DevTools/StatePanel.test.tsx
+++ b/packages/devtools-core/tests/components/DevTools/StatePanel.test.tsx
@@ -1,4 +1,3 @@
-import "@babel/polyfill";
 import * as React from "react";
 import { StatePanel } from "../../../src/App/DevTools/StatePanel";
 import { model } from "../../../src/model";

--- a/packages/devtools-core/tests/components/DevTools/components/JsonTree.test.tsx
+++ b/packages/devtools-core/tests/components/DevTools/components/JsonTree.test.tsx
@@ -1,4 +1,3 @@
-import "@babel/polyfill";
 import * as React from "react";
 import JsonTree from "../../../../src/App/DevTools/components/JsonTree";
 import { renderWithTheme } from "../../../utils";

--- a/packages/devtools-core/tests/components/DevTools/index.test.tsx
+++ b/packages/devtools-core/tests/components/DevTools/index.test.tsx
@@ -1,4 +1,3 @@
-import "@babel/polyfill";
 import { fireEvent } from "@testing-library/react";
 import * as React from "react";
 import { DevTools } from "../../../src/App/DevTools";

--- a/packages/devtools-core/tests/components/index.test.tsx
+++ b/packages/devtools-core/tests/components/index.test.tsx
@@ -1,4 +1,3 @@
-import "@babel/polyfill";
 import * as React from "react";
 import App from "../../src/App";
 import { model } from "../../src/model";

--- a/packages/devtools-core/tests/fixtures.tsx
+++ b/packages/devtools-core/tests/fixtures.tsx
@@ -1,7 +1,8 @@
 import { State } from "../src/model";
+import { Action, Render } from "../src/types";
 
 export const testAppState = { foo: "bar", items: [1, 2], test: { a: "b" } };
-export const testActionLog = [
+export const testActionLog: Action[] = [
   {
     actionName: "actionName1",
     id: "id1",
@@ -10,6 +11,8 @@ export const testActionLog = [
     nextActions: [],
     args: {},
     patches: [],
+    rerender: { Comp1: true },
+    pluginName: "",
   },
   {
     actionName: "actionName2",
@@ -19,6 +22,7 @@ export const testActionLog = [
     nextActions: [],
     args: {},
     patches: [],
+    pluginName: "",
   },
   {
     actionName: "actionName3",
@@ -28,10 +32,31 @@ export const testActionLog = [
     nextActions: [],
     args: {},
     patches: [],
+    rerender: { Comp1: true, Comp3: true },
+    pluginName: "",
+  },
+];
+
+export const testRenderLog: Render[] = [
+  {
+    componentId: "Comp1",
+    actionName: "actionName1",
+  },
+  {
+    componentId: "Comp1",
+    actionName: "actionName3",
+  },
+  {
+    componentId: "Comp3",
+    actionName: "actionName3",
   },
 ];
 
 export const populatedState: State = {
-  app: { state: testAppState, actionLog: testActionLog },
+  app: {
+    state: testAppState,
+    actionLog: testActionLog,
+    renderLog: testRenderLog,
+  },
   ui: { iframe: null },
 };

--- a/packages/devtools-core/tests/utils.tsx
+++ b/packages/devtools-core/tests/utils.tsx
@@ -1,4 +1,3 @@
-import "@babel/polyfill";
 import { Store } from "@prodo/core";
 import { Provider } from "@prodo/core/src";
 import { render } from "@testing-library/react";


### PR DESCRIPTION
Currently clears both logs, since they are both based off of the same data. Can separate functionality if people prefer though.

![Screenshot 2019-09-24 at 16 44 58](https://user-images.githubusercontent.com/1416759/65527499-aac10200-deea-11e9-9728-82574ed81a97.png)
