### PR TITLE
Create Prodo App

### DIFF
--- a/packages/create-prodo-app/package.json
+++ b/packages/create-prodo-app/package.json
@@ -7,6 +7,9 @@
     "lib",
     "src"
   ],
+  "bin": {
+    "create-prodo-app": "lib/index.js"
+  },
   "scripts": {
     "start": "ts-node src/index.ts",
     "build": "tsc --build",

--- a/packages/create-prodo-app/package.json
+++ b/packages/create-prodo-app/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "create-prodo-app",
+  "version": "0.0.7",
+  "main": "lib/index.js",
+  "license": "MIT",
+  "files": [
+    "lib",
+    "src"
+  ],
+  "scripts": {
+    "start": "ts-node src/index.ts",
+    "build": "tsc --build",
+    "clean": "rm -rf lib tsconfig.tsbuildinfo",
+    "lint": "set -ex; tsc --build; tslint --project ."
+  },
+  "dependencies": {
+    "chalk": "^2.4.2",
+    "commander": "^3.0.1",
+    "download-git-repo": "^2.0.0",
+    "tilde-path": "^3.0.0",
+    "validate-npm-package-name": "^3.0.0"
+  },
+  "devDependencies": {
+    "@types/chalk": "^2.2.0",
+    "@types/commander": "^2.12.2",
+    "@types/node": "^12.7.2",
+    "@types/validate-npm-package-name": "^3.0.0",
+    "ts-node": "^8.4.1",
+    "typescript": "^3.6.3"
+  }
+}

--- a/packages/create-prodo-app/src/index.ts
+++ b/packages/create-prodo-app/src/index.ts
@@ -85,11 +85,14 @@ const printSuccessMessage = (name: string, root: string) => {
 
 // remove references to prodo-template-* in newly created apps package.json
 const cleanupPackageJson = (name: string, root: string) => {
-  const userPackageJson = require(path.resolve(root, "package.json"));
+  const filename = path.resolve(root, "package.json");
+  const userPackageJson = require(filename);
 
   userPackageJson.name = name;
   userPackageJson.version = "0.1.0";
   delete userPackageJson.repository;
+
+  fs.writeFileSync(filename, JSON.stringify(userPackageJson, null, 2));
 };
 
 // delete files in newly created app that are not needed

--- a/packages/create-prodo-app/src/index.ts
+++ b/packages/create-prodo-app/src/index.ts
@@ -30,8 +30,8 @@ const program = new commander.Command(packageJson.name)
     logger.log(`    Only ${chalk.green("<project-directory>")} is required.`);
     logger.log();
   })
-  .option("--typescript", "Create project with TypeScript")
-  .option("--verbose", "Show more logging information")
+  .option("--typescript", "create project with TypeScript")
+  .option("--verbose", "show more logging information")
   .parse(process.argv);
 
 if (program.verbose) {

--- a/packages/create-prodo-app/src/index.ts
+++ b/packages/create-prodo-app/src/index.ts
@@ -1,0 +1,102 @@
+import chalk from "chalk";
+import * as commander from "commander";
+import * as downloadGitRepo from "download-git-repo";
+import * as fs from "fs";
+import * as path from "path";
+import * as tildePath from "tilde-path";
+import * as validateNpmPackageName from "validate-npm-package-name";
+import logger, { VerbosityLevel } from "./logger";
+
+// tslint:disable-next-line:no-var-requires
+const packageJson = require("../package.json");
+
+const typescriptTemplate = "github:prodo-ai/prodo-template";
+
+let projectName: string | null = null;
+
+const program = new commander.Command(packageJson.name)
+  .version(packageJson.version)
+  .arguments("<project-directory>")
+  .usage(`${chalk.green("<project-directory>")} [options]`)
+  .action(name => {
+    projectName = name;
+  })
+  .on("--help", () => {
+    logger.log();
+    logger.log(`    Only ${chalk.green("<project-directory>")} is required.`);
+    logger.log();
+  })
+  .option("--typescript", "Create project with TypeScript")
+  .option("--verbose", "Show more logging information")
+  .parse(process.argv);
+
+if (program.verbose) {
+  logger.setVerbosity(VerbosityLevel.debug);
+}
+
+if (projectName == null) {
+  logger.log("Please specify the project directory:");
+  logger.log();
+  logger.log("For example:");
+  logger.log(`  ${chalk.cyan(program.name())} ${chalk.green("my-prodo-app")}`);
+  logger.log();
+  logger.log(
+    `Run ${chalk.cyan(`${program.name()} --help`)} to see all options.`,
+  );
+  process.exit(1);
+}
+
+const downloadRepo = (template: string, dest: string): Promise<boolean> =>
+  new Promise((resolve, reject) => {
+    downloadGitRepo(template, dest, (err: any) => {
+      err == null ? resolve() : reject(err);
+    });
+  });
+
+const printSuccessMessage = (name: string, root: string) => {
+  logger.log(`Success! Created ${name} at ${tildePath(root)}`);
+  logger.log();
+  logger.log("Start your app with");
+  logger.log();
+  logger.log(`    ${chalk.cyan("cd")} ${name}`);
+  logger.log(`    ${chalk.cyan("yarn")}`);
+  logger.log(`    ${chalk.cyan("yarn start")}`);
+  logger.log();
+};
+
+const createApp = async (name: string, _useTypescript: boolean) => {
+  const root = path.resolve(name);
+
+  // validate project name
+  const validResult = validateNpmPackageName(name);
+  if (!validResult.validForNewPackages) {
+    logger.log();
+    logger.log(`${name} is an invalid package name`);
+    (validResult.warnings || []).forEach(s =>
+      logger.log("  " + chalk.yellow(s)),
+    );
+    (validResult.errors || []).forEach(s => logger.log("  " + chalk.red(s)));
+    logger.log();
+    process.exit(1);
+  }
+
+  // check directory is empty
+  if (fs.existsSync(root)) {
+    logger.log();
+    logger.log(`Cannot create app in existing directory`);
+    logger.log(`    ${chalk.magenta(root)}`);
+    process.exit(1);
+  }
+
+  // download template repo
+  try {
+    await downloadRepo(typescriptTemplate, root);
+  } catch (e) {
+    logger.log(chalk.red("Error downloading template repo."));
+    process.exit(1);
+  }
+
+  printSuccessMessage(name, root);
+};
+
+createApp(projectName!, program.typescript);

--- a/packages/create-prodo-app/src/index.ts
+++ b/packages/create-prodo-app/src/index.ts
@@ -1,4 +1,5 @@
 import chalk from "chalk";
+import * as childProcess from "child_process";
 import * as commander from "commander";
 import * as downloadGitRepo from "download-git-repo";
 import * as fs from "fs";
@@ -6,7 +7,6 @@ import * as path from "path";
 import * as tildePath from "tilde-path";
 import * as validateNpmPackageName from "validate-npm-package-name";
 import logger, { VerbosityLevel } from "./logger";
-import * as childProcess from "child_process";
 
 const execSync = childProcess.execSync;
 

--- a/packages/create-prodo-app/src/logger.ts
+++ b/packages/create-prodo-app/src/logger.ts
@@ -1,0 +1,43 @@
+export enum VerbosityLevel {
+  debug = 4,
+  info = 3,
+  warn = 2,
+  error = 1,
+}
+
+class Logger {
+  private verbosity: VerbosityLevel = VerbosityLevel.info;
+
+  public setVerbosity(verbosity: VerbosityLevel) {
+    this.verbosity = verbosity;
+  }
+
+  public debug(...args: any[]) {
+    this.logWithVerbosity(VerbosityLevel.debug, ...args);
+  }
+
+  public info(...args: any[]) {
+    this.logWithVerbosity(VerbosityLevel.info, ...args);
+  }
+
+  public log(...args: any[]) {
+    this.info(...args);
+  }
+
+  public warn(...args: any[]) {
+    this.logWithVerbosity(VerbosityLevel.warn, ...args);
+  }
+
+  public error(...args: any[]) {
+    this.logWithVerbosity(VerbosityLevel.error, ...args);
+  }
+
+  private logWithVerbosity(level: VerbosityLevel, ...args: any[]) {
+    if (level <= this.verbosity) {
+      // tslint:disable-next-line:no-console
+      console.log(...args);
+    }
+  }
+}
+
+export default new Logger();

--- a/packages/create-prodo-app/tsconfig.json
+++ b/packages/create-prodo-app/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.ui.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "lib"
+  },
+  "include": ["src"]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -23,6 +23,7 @@
     { "path": "packages/route-plugin" },
     { "path": "packages/stream-plugin" },
     { "path": "packages/devtools-core" },
-    { "path": "packages/devtools-plugin" }
+    { "path": "packages/devtools-plugin" },
+    { "path": "packages/create-prodo-app" }
   ]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2535,10 +2535,24 @@
     "@types/long" "*"
     "@types/node" "*"
 
+"@types/chalk@^2.2.0":
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/@types/chalk/-/chalk-2.2.0.tgz#b7f6e446f4511029ee8e3f43075fb5b73fbaa0ba"
+  integrity sha512-1zzPV9FDe1I/WHhRkf9SNgqtRJWZqrBWgu7JGveuHmmyR9CnAPCie2N/x+iHrgnpYBIcCJWHBoMRv2TRWktsvw==
+  dependencies:
+    chalk "*"
+
 "@types/classnames@^2.2.9":
   version "2.2.9"
   resolved "https://registry.yarnpkg.com/@types/classnames/-/classnames-2.2.9.tgz#d868b6febb02666330410fe7f58f3c4b8258be7b"
   integrity sha512-MNl+rT5UmZeilaPxAVs6YaPC2m6aA8rofviZbhbxpPpl61uKodfdQVsBtgJGTqGizEf02oW3tsVe7FYB8kK14A==
+
+"@types/commander@^2.12.2":
+  version "2.12.2"
+  resolved "https://registry.yarnpkg.com/@types/commander/-/commander-2.12.2.tgz#183041a23842d4281478fa5d23c5ca78e6fd08ae"
+  integrity sha512-0QEFiR8ljcHp9bAbWxecjVRuAMr16ivPiGOw6KFQBVrVd0RQIcM3xKdRisH2EDWgVWujiYtHwhSkSUoAAGzH7Q==
+  dependencies:
+    commander "*"
 
 "@types/configstore@^2.1.1":
   version "2.1.1"
@@ -2809,6 +2823,11 @@
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/@types/unist/-/unist-2.0.3.tgz#9c088679876f374eb5983f150d4787aa6fb32d7e"
   integrity sha512-FvUupuM3rlRsRtCN+fDudtmytGO6iHJuuRKS1Ss0pG5z8oX0diNEw94UEL7hgDbpN94rgaK5R7sWm6RrSkZuAQ==
+
+"@types/validate-npm-package-name@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@types/validate-npm-package-name/-/validate-npm-package-name-3.0.0.tgz#0bc835adc7d6f41cf96a59b591fe8699468f6fab"
+  integrity sha512-iFNNIrEaJH1lbPiyX+O/QyxSbKxrTjdNBVZGckt+iEL9So0hdZNBL68sOfHnt2txuUD8UJXvmKv/1DkgkebgUg==
 
 "@types/vfile-message@*":
   version "1.0.1"
@@ -3354,6 +3373,11 @@ are-we-there-yet@~1.1.2:
   dependencies:
     delegates "^1.0.0"
     readable-stream "^2.0.6"
+
+arg@^4.1.0:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/arg/-/arg-4.1.1.tgz#485f8e7c390ce4c5f78257dbea80d4be11feda4c"
+  integrity sha512-SlmP3fEA88MBv0PypnXZ8ZfJhwmDeIE3SP71j37AiXQBXYosPV0x6uISAaHYSlSVhmHOVkomen0tbGk6Anlebw==
 
 argparse@^1.0.7:
   version "1.0.10"
@@ -5123,6 +5147,15 @@ ccount@^1.0.0, ccount@^1.0.3:
   resolved "https://registry.yarnpkg.com/ccount/-/ccount-1.0.4.tgz#9cf2de494ca84060a2a8d2854edd6dfb0445f386"
   integrity sha512-fpZ81yYfzentuieinmGnphk0pLkOTMm6MZdVqwd77ROvhko6iujLNGrHH5E7utq3ygWklwfmwuG+A7P+NpqT6w==
 
+chalk@*, chalk@2.4.2, chalk@^2.0.0, chalk@^2.0.1, chalk@^2.1.0, chalk@^2.3.0, chalk@^2.3.1, chalk@^2.4.1, chalk@^2.4.2:
+  version "2.4.2"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.2.tgz#cd42541677a54333cf541a49108c1432b44c9424"
+  integrity sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==
+  dependencies:
+    ansi-styles "^3.2.1"
+    escape-string-regexp "^1.0.5"
+    supports-color "^5.3.0"
+
 chalk@1.1.3, chalk@^1.0.0, chalk@^1.1.1, chalk@^1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-1.1.3.tgz#a8115c55e4a702fe4d150abd3872822a7e09fc98"
@@ -5133,15 +5166,6 @@ chalk@1.1.3, chalk@^1.0.0, chalk@^1.1.1, chalk@^1.1.3:
     has-ansi "^2.0.0"
     strip-ansi "^3.0.0"
     supports-color "^2.0.0"
-
-chalk@2.4.2, chalk@^2.0.0, chalk@^2.0.1, chalk@^2.1.0, chalk@^2.3.0, chalk@^2.3.1, chalk@^2.4.1, chalk@^2.4.2:
-  version "2.4.2"
-  resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.2.tgz#cd42541677a54333cf541a49108c1432b44c9424"
-  integrity sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==
-  dependencies:
-    ansi-styles "^3.2.1"
-    escape-string-regexp "^1.0.5"
-    supports-color "^5.3.0"
 
 change-case@^3.1.0:
   version "3.1.0"
@@ -5577,6 +5601,11 @@ command-exists@^1.2.2:
   version "1.2.8"
   resolved "https://registry.yarnpkg.com/command-exists/-/command-exists-1.2.8.tgz#715acefdd1223b9c9b37110a149c6392c2852291"
   integrity sha512-PM54PkseWbiiD/mMsbvW351/u+dafwTJ0ye2qB60G1aGQP9j3xK2gmMDc+R34L3nDtx4qMCitXT75mkbkGJDLw==
+
+commander@*, commander@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-3.0.1.tgz#4595aec3530525e671fb6f85fb173df8ff8bf57a"
+  integrity sha512-UNgvDd+csKdc9GD4zjtkHKQbT8Aspt2jCBqNSPp53vAS0L1tS9sXB2TCEOPHJ7kt9bN/niWkYj8T3RQSoMXdSQ==
 
 commander@2.17.x:
   version "2.17.1"
@@ -7066,6 +7095,15 @@ dotenv@^8.1.0:
   version "8.1.0"
   resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-8.1.0.tgz#d811e178652bfb8a1e593c6dd704ec7e90d85ea2"
   integrity sha512-GUE3gqcDCaMltj2++g6bRQ5rBJWtkWTmqmD0fo1RnnMuUqHNCt2oTPeDnS9n6fKYvlhn7AeBkb38lymBtWBQdA==
+
+download-git-repo@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/download-git-repo/-/download-git-repo-2.0.0.tgz#0af3fe7c92de7d21827522969beeae0d06525a55"
+  integrity sha512-al8ZOwpm/DvCd7XC8PupeuNlC2TrvsMxW3FOx1bCbHNBhP1lYjOn9KnPqnZ3o/jz1vxCC5NHGJA7LT+GYMLcHA==
+  dependencies:
+    download "^7.1.0"
+    git-clone "^0.1.0"
+    rimraf "^2.6.3"
 
 download@^6.2.2:
   version "6.2.5"
@@ -9250,6 +9288,11 @@ getpass@^0.1.1:
   integrity sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=
   dependencies:
     assert-plus "^1.0.0"
+
+git-clone@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/git-clone/-/git-clone-0.1.0.tgz#0d76163778093aef7f1c30238f2a9ef3f07a2eb9"
+  integrity sha1-DXYWN3gJOu9/HDAjjyqe8/B6Lrk=
 
 git-raw-commits@2.0.0:
   version "2.0.0"
@@ -12601,7 +12644,7 @@ make-dir@^3.0.0:
   dependencies:
     semver "^6.0.0"
 
-make-error@1.x:
+make-error@1.x, make-error@^1.1.1:
   version "1.3.5"
   resolved "https://registry.yarnpkg.com/make-error/-/make-error-1.3.5.tgz#efe4e81f6db28cadd605c70f29c831b58ef776c8"
   integrity sha512-c3sIjNUow0+8swNwVpqoH4YCShKNFkMaw6oH1mNS2haDZQqkeZFlHS3dhoeEbKKmJB4vXpJucU6oH75aDYeE9g==
@@ -18145,6 +18188,11 @@ thunky@^1.0.2:
   resolved "https://registry.yarnpkg.com/thunky/-/thunky-1.0.3.tgz#f5df732453407b09191dae73e2a8cc73f381a826"
   integrity sha512-YwT8pjmNcAXBZqrubu22P4FYsh2D4dxRmnWBOL8Jk8bUcRUtc5326kx32tuTmFDAZtLOGEVNl8POAR8j896Iow==
 
+tilde-path@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/tilde-path/-/tilde-path-3.0.0.tgz#8d4ae06766e48c2ee7eed9239389734c8ff88c77"
+  integrity sha512-jHGx1beQCxoIuyg1LDKxqL3J0zNA57eGjlXsqtcjj6Q9EKXh4Sz895VxXW/psJW1PYIF79XViZEEWrvmhaZ61g==
+
 timed-out@^4.0.0, timed-out@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/timed-out/-/timed-out-4.0.1.tgz#f32eacac5a175bea25d7fab565ab3ed8741ef56f"
@@ -18398,6 +18446,17 @@ ts-jest@^24.0.2:
     resolve "1.x"
     semver "^5.5"
     yargs-parser "10.x"
+
+ts-node@^8.4.1:
+  version "8.4.1"
+  resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-8.4.1.tgz#270b0dba16e8723c9fa4f9b4775d3810fd994b4f"
+  integrity sha512-5LpRN+mTiCs7lI5EtbXmF/HfMeCjzt7DH9CZwtkr6SywStrNQC723wG+aOWFiLNn7zT3kD/RnFqi3ZUfr4l5Qw==
+  dependencies:
+    arg "^4.1.0"
+    diff "^4.0.1"
+    make-error "^1.1.1"
+    source-map-support "^0.5.6"
+    yn "^3.0.0"
 
 ts-pnp@^1.1.2:
   version "1.1.4"
@@ -19958,6 +20017,11 @@ yeast@0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/yeast/-/yeast-0.1.2.tgz#008e06d8094320c372dbc2f8ed76a0ca6c8ac419"
   integrity sha1-AI4G2AlDIMNy28L47XagymyKxBk=
+
+yn@^3.0.0:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/yn/-/yn-3.1.1.tgz#1e87401a09d767c1d5eab26a6e4c185182d2eb50"
+  integrity sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==
 
 yoga-layout-prebuilt@^1.9.3:
   version "1.9.3"


### PR DESCRIPTION
Script similar to https://github.com/facebook/create-react-app/blob/master/packages/create-react-app/createReactApp.js

This package needs to `create-prodo-app` on NPM so we can use [yarn create](https://yarnpkg.com/lang/en/docs/cli/create/) and [npx](https://www.npmjs.com/package/npx) easily.

Creating a prodo app
- Checks if app name is valid
- Checks if app directory does not exist
- Downloads either [prodo-template-js](https://github.com/prodo-ai/prodo-template-js/) or [prodo-template](https://github.com/prodo-ai/prodo-template/) depending on if the `--typescript` option was provided
- Remove references to prodo in users `app package.json`

<img width="573" alt="image" src="https://user-images.githubusercontent.com/3044853/65539320-1dd57300-df01-11e9-9f83-56ccb64eeafa.png">
