### PR TITLE
Better error messages for invalid use of model.ctx

### DIFF
--- a/packages/core/src/model.ts
+++ b/packages/core/src/model.ts
@@ -4,6 +4,9 @@ import { ProdoPlugin } from "./plugins";
 import { createStore } from "./store";
 import { Dispatch, Model, Watch } from "./types";
 
+const invalidCtxUseMessage = (value: string | number | symbol) =>
+  `Cannot use ${value.toString()} outside of an action or React component.`;
+
 export const createModel = <State>(): Model<
   { initState: State },
   { state: State },
@@ -20,7 +23,17 @@ export const createModel = <State>(): Model<
       plugins.push(p);
       return model;
     },
-    ctx: {} as any,
+    ctx: new Proxy(
+      {},
+      {
+        get(_target, key) {
+          throw new Error(invalidCtxUseMessage(key));
+        },
+        set(_target, key) {
+          throw new Error(invalidCtxUseMessage(key));
+        },
+      },
+    ),
   };
 
   return model as any;


### PR DESCRIPTION
Closes #34 

![image](https://user-images.githubusercontent.com/3044853/65605199-9b03f500-dfa0-11e9-8e0d-d28895b53331.png)
