### PR TITLE
Rename devtools-plugin to devtools

### DIFF
--- a/docs/content/02_basics/devtools.md
+++ b/docs/content/02_basics/devtools.md
@@ -5,7 +5,7 @@ order: 8
 
 # Installation
 
-Add the devtools-plugin to your application so that your app and the devtools can communicate properly. You can find details [here](https://docs.prodo.dev/plugins/devtools/).
+Add the devtools plugin to your application so that your app and the devtools can communicate properly. You can find details [here](https://docs.prodo.dev/plugins/devtools/).
 
 Once you have installed the developer tools and turned them on as described above, they will appear to the side of your application when you start it up as normal. If you want to hide them, just toggle `devtools` to `false`.
 

--- a/docs/content/03_plugins/devtools.md
+++ b/docs/content/03_plugins/devtools.md
@@ -8,14 +8,14 @@ Adds the prodo developer tools to your application.
 ## Installation
 
 ```shell
-npm install --save @prodo/devtools-plugin
+npm install --save @prodo/devtools
 ```
 
 ## Add to your model
 
 ```ts
 // src/model.ts
-import devToolsPlugin from "@prodo/devtools-plugin";
+import devToolsPlugin from "@prodo/devtools";
 
 // ...
 

--- a/examples/kanban/package.json
+++ b/examples/kanban/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "@prodo/core": "^0.0.8",
-    "@prodo/devtools-plugin": "^0.0.8",
+    "@prodo/devtools": "^0.0.8",
     "@prodo/effect": "^0.0.8",
     "@prodo/logger": "^0.0.8",
     "@prodo/route": "^0.0.8",

--- a/examples/kanban/src/model.tsx
+++ b/examples/kanban/src/model.tsx
@@ -1,5 +1,5 @@
 import { createModel } from "@prodo/core";
-import devToolsPlugin from "@prodo/devtools-plugin";
+import devToolsPlugin from "@prodo/devtools";
 import effectPlugin from "@prodo/effect";
 import loggerPlugin from "@prodo/logger";
 import routePlugin from "@prodo/route";

--- a/examples/todo-app/package.json
+++ b/examples/todo-app/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "@prodo/core": "^0.0.8",
-    "@prodo/devtools-plugin": "^0.0.8",
+    "@prodo/devtools": "^0.0.8",
     "@prodo/effect": "^0.0.8",
     "@prodo/logger": "^0.0.8",
     "core-js": "2",

--- a/examples/todo-app/src/model.ts
+++ b/examples/todo-app/src/model.ts
@@ -1,5 +1,5 @@
 import { createModel } from "@prodo/core";
-import devToolsPlugin from "@prodo/devtools-plugin";
+import devToolsPlugin from "@prodo/devtools";
 import effectPlugin from "@prodo/effect";
 import loggerPlugin from "@prodo/logger";
 

--- a/packages/devtools-core/.babelrc
+++ b/packages/devtools-core/.babelrc
@@ -2,7 +2,7 @@
   "presets": [
     "@babel/preset-typescript",
     "@babel/preset-react",
-    ["@babel/preset-env", { "useBuiltIns": "usage" }]
+    ["@babel/preset-env", { "useBuiltIns": "usage", "corejs": 2 }]
   ],
   "plugins": ["@babel/plugin-proposal-class-properties", "@prodo/babel-plugin"]
 }

--- a/packages/devtools-core/README.md
+++ b/packages/devtools-core/README.md
@@ -5,16 +5,15 @@ The tools are implemented in Prodo.
 
 ## Installation
 
-Add the devtools-plugin to your model so that your app and the devtools can communicate properly.
+Add the devtools plugin to your model so that your app and the devtools can communicate properly.
 
 ```ts
 import { createModel } from "@prodo/core";
-import devToolsPlugin from "@prodo/devtools-plugin";
+import devToolsPlugin from "@prodo/devtools";
 
 export interface State {}
 
-export const model = createModel<State>()
-  .with(devToolsPlugin);
+export const model = createModel<State>().with(devToolsPlugin);
 ```
 
 To show the devtools next to your app, turn the `devtools` variable to true when you create your store.

--- a/packages/devtools-plugin/package.json
+++ b/packages/devtools-plugin/package.json
@@ -14,12 +14,12 @@
     "lint": "set -ex; tsc --build; tslint --project ."
   },
   "dependencies": {
+    "@prodo/devtools-core": "^0.0.8",
     "immer": "^3.2.0",
     "lodash": "^4.17.15"
   },
   "devDependencies": {
     "@prodo/core": "^0.0.8",
-    "@prodo/devtools-core": "^0.0.8",
     "@types/jest": "^24.0.18",
     "ts-jest": "^24.0.2"
   },

--- a/packages/devtools-plugin/package.json
+++ b/packages/devtools-plugin/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@prodo/devtools-plugin",
+  "name": "@prodo/devtools",
   "version": "0.0.8",
   "main": "lib/index.js",
   "license": "MIT",


### PR DESCRIPTION
Would close https://github.com/prodo-ai/prodo/issues/108#event-2662330277 (and start on https://github.com/prodo-ai/prodo/issues/109#event-2662493838  by moving devtools-core from dev to real dependencies)

Edit: the corejs fix may help with the react-editable-json-tree problem too.
