### PR TITLE
Fix devtools dependencies

### DIFF
--- a/packages/devtools-core/package.json
+++ b/packages/devtools-core/package.json
@@ -39,6 +39,7 @@
     "@types/testing-library__react": "^9.1.1",
     "@types/webpack-env": "^1.14.0",
     "babel-loader": "^8.0.6",
+    "babel-runtime": "^6.26.0",
     "css-loader": "^3.2.0",
     "fork-ts-checker-webpack-plugin": "^1.5.0",
     "html-webpack-plugin": "^3.2.0",


### PR DESCRIPTION
I think this should fix https://github.com/prodo-ai/prodo/issues/109.

The errors were of the form:
```
ERROR in ./node_modules/react-editable-json-tree/dist/components/JsonObject.js
Module not found: Error: Can't resolve 'babel-runtime/core-js/object/get-own-property-names' in '/Users/andrejakogovsek/Projects/ak-app/node_modules/react-editable-json-tree/dist/components'
```

Adding this to my prodo app dev dependencies made the errors go away.