### PR TITLE
More padding for inline code

### DIFF
--- a/docs/src/styles/highlight.css
+++ b/docs/src/styles/highlight.css
@@ -5,9 +5,9 @@
  */
 code[class*="language-"],
 pre[class*="language-"] {
-  color: #ABB2BF;
+  color: #abb2bf;
   background: none;
-  font-family: Consolas, Monaco, 'Andale Mono', 'Ubuntu Mono', monospace;
+  font-family: Consolas, Monaco, "Andale Mono", "Ubuntu Mono", monospace;
   text-align: left;
   white-space: pre;
   word-spacing: normal;
@@ -23,14 +23,18 @@ pre[class*="language-"] {
   hyphens: none;
 }
 
-pre[class*="language-"]::-moz-selection, pre[class*="language-"] ::-moz-selection,
-code[class*="language-"]::-moz-selection, code[class*="language-"] ::-moz-selection {
+pre[class*="language-"]::-moz-selection,
+pre[class*="language-"] ::-moz-selection,
+code[class*="language-"]::-moz-selection,
+code[class*="language-"] ::-moz-selection {
   text-shadow: none;
   background: #383e49;
 }
 
-pre[class*="language-"]::selection, pre[class*="language-"] ::selection,
-code[class*="language-"]::selection, code[class*="language-"] ::selection {
+pre[class*="language-"]::selection,
+pre[class*="language-"] ::selection,
+code[class*="language-"]::selection,
+code[class*="language-"] ::selection {
   text-shadow: none;
   background: #9aa2b1;
 }
@@ -44,7 +48,7 @@ code[class*="language-"]::selection, code[class*="language-"] ::selection {
 /* Code blocks */
 pre[class*="language-"] {
   padding: 1em;
-  margin: .5em 0;
+  margin: 0.5em 0;
   overflow: auto;
 }
 
@@ -55,8 +59,8 @@ pre[class*="language-"] {
 
 /* Inline code */
 :not(pre) > code[class*="language-"] {
-  padding: .1em;
-  border-radius: .3em;
+  padding: 0.25em;
+  border-radius: 0.3em;
   white-space: normal;
 }
 
@@ -64,7 +68,7 @@ pre[class*="language-"] {
 .token.prolog,
 .token.doctype,
 .token.cdata {
-  color: #5C6370;
+  color: #5c6370;
 }
 
 .token.punctuation {
@@ -154,7 +158,6 @@ pre.line-numbers > code {
   -moz-user-select: none;
   -ms-user-select: none;
   user-select: none;
-
 }
 
 .line-numbers-rows > span {
@@ -165,7 +168,7 @@ pre.line-numbers > code {
 
 .line-numbers-rows > span:before {
   content: counter(linenumber);
-  color: #5C6370;
+  color: #5c6370;
   display: block;
   padding-right: 0.8em;
   text-align: right;


### PR DESCRIPTION
Before:

<img width="960" alt="Screenshot 2019-09-29 at 11 55 57" src="https://user-images.githubusercontent.com/5788205/65831312-2090e900-e2b0-11e9-9c12-f81349b6b112.png">

After:

<img width="981" alt="Screenshot 2019-09-29 at 11 55 11" src="https://user-images.githubusercontent.com/5788205/65831313-24247000-e2b0-11e9-95ba-9fa81771fc8a.png">
