### PR TITLE
Docs ToC

### DIFF
--- a/docs/content/01_introduction/getting-started.md
+++ b/docs/content/01_introduction/getting-started.md
@@ -1,22 +1,13 @@
 ---
 title: "Getting Started"
 order: 1
+toc: true
 ---
 
 Prodo is a web framework that enables you to write performant and scalable web
 apps with as little boilerplate as possible. It was designed with TypeScript in
 mind and even includes a babel plugin to further reduce the amount of
 boilerplate.
-
-# Index
-
-- [Setup](#setup)
-- [Basic example](#basic-example)
-  - [Specifying the model](#1.-specifying-the-model)
-  - [Defining actions](#2.-defining-actions)
-  - [React components](#3.-react-components)
-- [Creating the store](#creating-the-store)
-- [Running your application](#running-your-application)
 
 # Setup
 
@@ -52,7 +43,7 @@ The typical workflow in developing a Prodo app is to
 2. **Define your actions as simple functions mutating the state of your model**
 3. **Use functional React components to render the model in its current state**
 
-## 1. Specifying the Model
+## Specifying the Model
 
 The [model](/basics/model) holds all of the types used in your actions and components
 in a file called `src/model.ts`.
@@ -73,7 +64,7 @@ and export any variables from our model that are used elsewhere in our app.
 These variables that are exported from our model are correctly typed with our
 state.
 
-## 2. Defining Actions
+## Defining Actions
 
 [Actions](/basics/actions) are simple functions that can read from the state and write to the state. They can
 take arguments, trigger side effects (see [effect plugin](/plugins/effects)), and dispatch other actions (see [dispatch](/basics/actions#dispatch)). We can create
@@ -94,7 +85,7 @@ be triggered in a component or another action with the `dispatch` function.
 dispatch(changeCount)(1);
 ```
 
-## 3. React Components
+## React Components
 
 [Components](/basics/components) take the state of your application and render it as JSX. Those components are writen with React and let you automatically "watch" for changes to the state. Under the hood, the component will start a subscription to the corresponding state path and trigger a re-render whenever the value changes.
 

--- a/docs/content/04_advanced/creating-plugins.md
+++ b/docs/content/04_advanced/creating-plugins.md
@@ -2,6 +2,7 @@
 title: "Creating Plugins"
 order: 1
 experimental: true
+toc: true
 ---
 
 Prodo plugins are an essential part of the framework and can add a lot of
@@ -12,6 +13,8 @@ functionality to a user's app. Plugins have the power to:
 - Subscribe a component to a particular part of the [universe](./universe) so
   the component will re-render when that data changes.
 - Wrap the entire user app with a React component.
+
+# Plugin Type
 
 A plugin is parameterised by five type parameters. These are:
 
@@ -51,6 +54,8 @@ const myPlugin = createPlugin<Config, Universe, ActionCtx, ViewCtx>(
 
 export default myPlugin;
 ```
+
+# Plugin Methods
 
 Functionality is added to plugins by calling functions on the plugin object that
 add _hooks_ into different parts of the framework. The available hooks are:

--- a/docs/src/templates/Docs.tsx
+++ b/docs/src/templates/Docs.tsx
@@ -3,7 +3,6 @@ import { MDXRenderer } from "gatsby-plugin-mdx";
 import * as React from "react";
 import DocsLayout from "../components/DocsLayout";
 import SEO from "../components/SEO";
-import { Title } from "../components/Text";
 
 export interface Props {
   data: {
@@ -12,7 +11,9 @@ export interface Props {
         title: string;
         experimental?: boolean;
         wip?: boolean;
+        toc?: boolean;
       };
+      headings: Array<{ value: string; depth: number }>;
       body: string;
       excerpt: string;
     };
@@ -24,9 +25,11 @@ const Docs = ({ data }: Props) => {
     <DocsLayout
       experimental={data.mdx.frontmatter.experimental}
       wip={data.mdx.frontmatter.wip}
+      toc={data.mdx.frontmatter.toc}
+      headings={data.mdx.headings}
+      title={data.mdx.frontmatter.title}
     >
       <SEO title={data.mdx.frontmatter.title} description={data.mdx.excerpt} />
-      <Title>{data.mdx.frontmatter.title}</Title>
       <MDXRenderer>{data.mdx.body}</MDXRenderer>
     </DocsLayout>
   );
@@ -41,6 +44,11 @@ export const pageQuery = graphql`
         title
         experimental
         wip
+        toc
+      }
+      headings {
+        value
+        depth
       }
       body
       excerpt

--- a/docs/src/templates/DocsSection.tsx
+++ b/docs/src/templates/DocsSection.tsx
@@ -3,7 +3,6 @@ import * as React from "react";
 import styled from "styled-components";
 import DocsLayout from "../components/DocsLayout";
 import Link from "../components/Link";
-import { Title } from "../components/Text";
 import { normalize } from "../utils";
 
 export interface Props {
@@ -38,8 +37,7 @@ const DocsSection = (props: Props) => {
   );
 
   return (
-    <DocsLayout>
-      <Title>{normalize(props.pageContext.name)}</Title>
+    <DocsLayout title={normalize(props.pageContext.name)}>
       {subSections.map(subSection => (
         <SubSectionLink
           key={subSection.fields.slug}


### PR DESCRIPTION
Simple table of contents at the top of docs pages. 

- Showing the toc is opt-in
- Only headings levels 1 and 2 are displayed
- Only getting started and creating plugin pages have it

![image](https://user-images.githubusercontent.com/3044853/65881298-198ad900-e38b-11e9-8f9a-5dd478540c23.png)
