### PR TITLE
Make sure load is called in Chrome

### DIFF
--- a/packages/devtools-core/src/App/UserAppContainer/index.tsx
+++ b/packages/devtools-core/src/App/UserAppContainer/index.tsx
@@ -35,16 +35,15 @@ const UserAppContainer = (props: Props) => {
 
   React.useEffect(() => {
     if (iFrameRef && iFrameRef.current && iFrameRef.current.contentWindow) {
-      iFrameRef.current.contentWindow.addEventListener("load", handleLoad);
       iFrameRef.current.contentWindow.addEventListener(
         "message",
         eventListener(dispatch),
       );
 
+      // Needed for Chrome
       handleLoad();
       return () => {
         if (iFrameRef && iFrameRef.current && iFrameRef.current.contentWindow) {
-          iFrameRef.current.removeEventListener("load", handleLoad);
           iFrameRef.current.contentWindow.removeEventListener(
             "message",
             eventListener(dispatch),
@@ -86,6 +85,7 @@ const UserAppContainer = (props: Props) => {
     return [];
   };
 
+  // onLoad={handleLoad} is needed for Firefox
   return (
     <StyledUserAppContainer
       className="userAppContainer"

--- a/packages/devtools-core/src/App/UserAppContainer/index.tsx
+++ b/packages/devtools-core/src/App/UserAppContainer/index.tsx
@@ -40,6 +40,8 @@ const UserAppContainer = (props: Props) => {
         "message",
         eventListener(dispatch),
       );
+
+      handleLoad();
       return () => {
         if (iFrameRef && iFrameRef.current && iFrameRef.current.contentWindow) {
           iFrameRef.current.removeEventListener("load", handleLoad);
@@ -99,7 +101,12 @@ const UserAppContainer = (props: Props) => {
             onLoad={handleLoad}
           />
         ) : (
-          <StyledIFrame ref={iFrameRef} className="iframe" data-testid="iframe">
+          <StyledIFrame
+            ref={iFrameRef}
+            className="iframe"
+            data-testid="iframe"
+            onLoad={handleLoad}
+          >
             {renderFrameContents()}
           </StyledIFrame>
         )}


### PR DESCRIPTION
Chrome doesn't really trigger "load" events on the iFrame, so we have to trigger it manually.

(also noticed one of the options was missing the handler, but it did seem to be working okay before...)

Would close https://github.com/prodo-ai/prodo/issues/124
