### PR TITLE
Add installation page to the docs

### DIFF
--- a/docs/content/01_introduction/benefits.md
+++ b/docs/content/01_introduction/benefits.md
@@ -1,6 +1,6 @@
 ---
 title: "Benefits"
-order: 3
+order: 2
 ---
 
 Below are a few snippets of code illustrating the key benefits of Prodo.

--- a/docs/content/01_introduction/installation.md
+++ b/docs/content/01_introduction/installation.md
@@ -1,0 +1,17 @@
+---
+title: "Installation"
+order: 3
+---
+
+Prodo is [available on NPM](https://www.npmjs.com/package/@prodo/core). The
+base package you need for all Prodo apps is `@prodo/core`.
+
+```shell
+npm install --save @prodo/core
+# OR
+yarn add @prodo/core
+```
+
+Prodo also provides a [Babel plugin](https://babeljs.io/)
+that enables you to write components and actions in a concise syntax. Check out
+[the docs](/basics/babel-plugin/) for information on how to set it up.


### PR DESCRIPTION
After adding create-prodo-app, we have removed all information on how to just install prodo with npm or yarn. This PR adds an installation page in the introduction. Address feedback in https://github.com/prodo-ai/prodo/issues/132.

<img width="1260" alt="image" src="https://user-images.githubusercontent.com/3044853/65991637-900c0180-e485-11e9-9012-18fab6af9fb9.png">
