### PR TITLE
fix typo, simplify and no default export

### DIFF
--- a/packages/eslint-plugin/src/configs/base.json
+++ b/packages/eslint-plugin/src/configs/base.json
@@ -1,5 +1,0 @@
-{
-  "parser": "@typescript-eslint/parser",
-  "parserOptions": { "sourceType": "module" },
-  "plugins": ["@prodo/eslint-plugin"]
-}

--- a/packages/eslint-plugin/src/configs/recommended.ts
+++ b/packages/eslint-plugin/src/configs/recommended.ts
@@ -1,5 +1,4 @@
 export default {
-  extends: ".configs/base.json",
   rules: {
     "@prodo/no-state-access": "error",
     "@prodo/require-dispatched-action-is-called": "error",

--- a/packages/eslint-plugin/src/index.ts
+++ b/packages/eslint-plugin/src/index.ts
@@ -1,4 +1,6 @@
 import recommended from "./configs/recommended";
 import rules from "./rules";
 
-export default { rules, configs: { recommended } };
+export { rules };
+const configs = { recommended };
+export { configs };

--- a/packages/eslint-plugin/src/index.ts
+++ b/packages/eslint-plugin/src/index.ts
@@ -1,6 +1,5 @@
 import recommended from "./configs/recommended";
 import rules from "./rules";
 
-export { rules };
 const configs = { recommended };
-export { configs };
+export { rules, configs };


### PR DESCRIPTION
Fixing mistake from #138:

- no default export
- typo in path for base.json, but the contents of that file aren't actually necessary.

