### PR TITLE
check def exists before accessing node

### DIFF
--- a/packages/eslint-plugin/src/utils/findDefinition.ts
+++ b/packages/eslint-plugin/src/utils/findDefinition.ts
@@ -13,7 +13,8 @@ export const findDefinition = (
   if (reference) {
     const resolved = reference.resolved;
     if (resolved) {
-      return resolved.defs[resolved.defs.length - 1].node;
+      const lastResolved = resolved.defs[resolved.defs.length - 1];
+      return lastResolved != null ? lastResolved.node : undefined;
     }
   }
   return undefined;

--- a/packages/eslint-plugin/tests/rulesTs/no-state-access.test.ts
+++ b/packages/eslint-plugin/tests/rulesTs/no-state-access.test.ts
@@ -75,6 +75,12 @@ ruleTester.run("no-state-access", rule, {
       filename: defaultTsFile,
     },
     {
+      code: `import * as model from './model';
+      const today = Date.now();
+      model.dispatch(foo)(today);`,
+      filename: defaultTsFile,
+    },
+    {
       code: `import {state, foo} from './model'; 
         const x = 1;
         foo(x); 


### PR DESCRIPTION
Simple fix for bug. I saw the following error when linting a file that included builtin variables (`Date`, `console` etc). Fixed by checking that the definition exists before accessing node in the `findDefinition` function. 

```TypeError: Cannot read property 'node' of undefined
Occurred while linting /prodo/examples/chess-app/src/App.tsx:6
    at Object.exports.findDefinition (/prodo/packages/eslint-plugin/lib/utils/findDefinition.js:10:60)
    at CallExpression:not(CallExpression > CallExpression.callee) (/prodo/packages/eslint-plugin/lib/rules/require-dispatched-action-is-called.js:40:58)
    at listeners.(anonymous function).forEach.listener (/prodo/node_modules/eslint/lib/linter/safe-emitter.js:45:58)
    at Array.forEach (<anonymous>)
    at Object.emit (/prodo/node_modules/eslint/lib/linter/safe-emitter.js:45:38)
    at NodeEventGenerator.applySelector
...
...
```