### PR TITLE
add publishConfig to all public packages

### DIFF
--- a/packages/babel-plugin/package.json
+++ b/packages/babel-plugin/package.json
@@ -30,5 +30,8 @@
     "transform": {
       "^.+\\.tsx?$": "ts-jest"
     }
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -31,5 +31,8 @@
     "transform": {
       "^.+\\.tsx?$": "ts-jest"
     }
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/packages/create-prodo-app/package.json
+++ b/packages/create-prodo-app/package.json
@@ -30,5 +30,8 @@
     "@types/validate-npm-package-name": "^3.0.0",
     "ts-node": "^8.4.1",
     "typescript": "^3.6.3"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/packages/devtools-core/package.json
+++ b/packages/devtools-core/package.json
@@ -60,5 +60,8 @@
     "moduleNameMapper": {
       "\\.(svg|jpg|scss|css|png)$": "<rootDir>/tests/__mock__.js"
     }
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/packages/devtools-plugin/package.json
+++ b/packages/devtools-plugin/package.json
@@ -27,5 +27,8 @@
     "transform": {
       "^.+\\.tsx?$": "ts-jest"
     }
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -35,5 +35,8 @@
         "diagnostics": false
       }
     }
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/packages/local-plugin/package.json
+++ b/packages/local-plugin/package.json
@@ -26,5 +26,8 @@
     "transform": {
       "^.+\\.tsx?$": "ts-jest"
     }
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/packages/logger-plugin/package.json
+++ b/packages/logger-plugin/package.json
@@ -22,5 +22,8 @@
     "transform": {
       "^.+\\.tsx?$": "ts-jest"
     }
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/packages/route-plugin/package.json
+++ b/packages/route-plugin/package.json
@@ -13,6 +13,11 @@
     "test": "jest",
     "lint": "set -ex; tsc --build; tslint --project ."
   },
+  "dependencies": {
+    "history": "^4.9.0",
+    "path-to-regexp": "^3.1.0",
+    "react": "^16.9.0"
+  },
   "devDependencies": {
     "@prodo/core": "^0.0.11",
     "@types/history": "^4.7.3",
@@ -29,9 +34,7 @@
       "^.+\\.tsx?$": "ts-jest"
     }
   },
-  "dependencies": {
-    "history": "^4.9.0",
-    "path-to-regexp": "^3.1.0",
-    "react": "^16.9.0"
+  "publishConfig": {
+    "access": "public"
   }
 }


### PR DESCRIPTION
I know that when I publish the eslint-plugin lerna will fail because it is a scoped package and we do not have private packages enabled for the `@prodo` org. This PR follows this https://github.com/lerna/lerna/pull/1139, which will hopefully publish publically initially. 🤞 