### PR TITLE
Embed codesandbox in examples and tutorial

### DIFF
--- a/docs/content/01_introduction/examples.md
+++ b/docs/content/01_introduction/examples.md
@@ -4,14 +4,17 @@ order: 6
 ---
 
 This page contains examples that use the Prodo framework. You can view them and
-edit their code on [Code Sandbox](https://codesandbox.io). The plugins and
-features used are listed.
+edit their code on [Code Sandbox](https://codesandbox.io). You can also view the
+examples in the [Prodo repo](https://github.com/prodo-ai/prodo/tree/master/examples).
 
-# To-Do App
+# Counter
 
-- Core
+<iframe src="https://codesandbox.io/embed/prodo-counter-ts-9n7tx?fontsize=14&module=%2Fsrc%2Fmodel.ts" title="Prodo Counter TS" allow="geolocation; microphone; camera; midi; vr; accelerometer; gyroscope; payment; ambient-light-sensor; encrypted-media; usb" style="width:100%; height:500px; border:0; border-radius: 4px; overflow:hidden;" sandbox="allow-modals allow-forms allow-popups allow-scripts allow-same-origin"></iframe>
 
-# Clock App
+# TodoMVC
 
-- Core
-- [Stream plugin](/plugins/streams)
+<iframe src="https://codesandbox.io/embed/prodo-todomvc-wf4nv?fontsize=14&module=%2Fsrc%2Fmodel.ts" title="Prodo TodoMVC" allow="geolocation; microphone; camera; midi; vr; accelerometer; gyroscope; payment; ambient-light-sensor; encrypted-media; usb" style="width:100%; height:500px; border:0; border-radius: 4px; overflow:hidden;" sandbox="allow-modals allow-forms allow-popups allow-scripts allow-same-origin"></iframe>
+
+# Github PR List
+
+<iframe src="https://codesandbox.io/embed/github-pr-list-noxhw?fontsize=14&module=%2Fsrc%2Fmodel.ts" title="Github PR List" allow="geolocation; microphone; camera; midi; vr; accelerometer; gyroscope; payment; ambient-light-sensor; encrypted-media; usb" style="width:100%; height:500px; border:0; border-radius: 4px; overflow:hidden;" sandbox="allow-modals allow-forms allow-popups allow-scripts allow-same-origin"></iframe>

--- a/docs/content/05_tutorials/github-prs.md
+++ b/docs/content/05_tutorials/github-prs.md
@@ -9,7 +9,9 @@ requests](https://help.github.com/en/articles/about-pull-requests) on Github for
 a repo. You can find the completed app and code in the following links.
 
 - [Deployed app](https://prodo-github-prs.netlify.com/)
-- [Code](https://github.com/prodo-ai/github-prs)
+- [Github](https://github.com/prodo-ai/github-prs)
+
+[![Edit Github PR List](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github-pr-list-noxhw?fontsize=14&module=%2Fsrc%2Fmodel.ts)
 
 # Create Prodo App
 
@@ -487,6 +489,12 @@ If you navigate to
 see something like:
 
 ![pull request list for facebook react](pr-list.png)
+
+# Final result
+
+The app we built can be seen in the following CodeSandbox
+
+<iframe src="https://codesandbox.io/embed/github-pr-list-noxhw?fontsize=14&module=%2Fsrc%2Fmodel.ts" title="Github PR List" allow="geolocation; microphone; camera; midi; vr; accelerometer; gyroscope; payment; ambient-light-sensor; encrypted-media; usb" style="width:100%; height:500px; border:0; border-radius: 4px; overflow:hidden;" sandbox="allow-modals allow-forms allow-popups allow-scripts allow-same-origin"></iframe>
 
 # Next steps
 


### PR DESCRIPTION
Do we want an embeded codesandbox on the homepage of the docs?

![image](https://user-images.githubusercontent.com/3044853/66130094-12610680-e5e9-11e9-9727-7b1eabb61bd5.png)
