### PR TITLE
Use unstable_batchedUpdates to group setState

### DIFF
--- a/examples/benchmark/.babelrc
+++ b/examples/benchmark/.babelrc
@@ -1,0 +1,8 @@
+{
+  "presets": [
+    "@babel/preset-typescript",
+    "@babel/preset-react",
+    ["@babel/preset-env", { "useBuiltIns": "usage", "corejs": 2 }]
+  ],
+  "sourceMaps": "both"
+}

--- a/examples/benchmark/README.md
+++ b/examples/benchmark/README.md
@@ -1,6 +1,8 @@
-# Prodo Clock
+# Benchmark
 
-This is a simple todo app example that uses the [Prodo](https://prodo.dev) framework.
+This is a synthetic benchmark that compares the time taken to update the state
+of many elements in the [Prodo](https://prodo.dev) framework and [React
+Redux](https://react-redux.js.org/).
 
 ## Running
 

--- a/examples/benchmark/README.md
+++ b/examples/benchmark/README.md
@@ -1,0 +1,10 @@
+# Prodo Clock
+
+This is a simple todo app example that uses the [Prodo](https://prodo.dev) framework.
+
+## Running
+
+```
+yarn
+yarn start
+```

--- a/examples/benchmark/package.json
+++ b/examples/benchmark/package.json
@@ -1,0 +1,51 @@
+{
+  "name": "@prodo-example/benchmark",
+  "version": "0.1.0",
+  "license": "MIT",
+  "private": true,
+  "scripts": {
+    "clean": "rm -rf .cache build dist lib tsconfig.tsbuildinfo",
+    "start": "webpack-dev-server --config webpack.config.js --history-api-fallback --hot",
+    "lint": "set -ex; tsc --build; tslint --project ."
+  },
+  "dependencies": {
+    "@prodo/core": "^0.1.0",
+    "core-js": "2",
+    "react": "^16.8.6",
+    "react-dom": "^16.9.0",
+    "react-redux": "^7.1.1",
+    "redux": "^4.0.4",
+    "redux-thunk": "^2.3.0"
+  },
+  "devDependencies": {
+    "@babel/core": "^7.5.5",
+    "@testing-library/react": "^9.1.3",
+    "@types/jest": "^24.0.18",
+    "@types/node": "^12.7.2",
+    "@types/react": "^16.8.25",
+    "@types/react-dom": "^16.8.5",
+    "@types/testing-library__react": "^9.1.1",
+    "@types/webpack-env": "^1.14.0",
+    "babel-loader": "^8.0.6",
+    "babel-preset-env": "^1.7.0",
+    "babel-preset-react": "^6.24.1",
+    "css-loader": "^3.2.0",
+    "fork-ts-checker-webpack-plugin": "^1.5.0",
+    "html-webpack-plugin": "^3.2.0",
+    "jest": "^24.9.0",
+    "node-sass": "^4.12.0",
+    "sass": "^1.22.9",
+    "sass-loader": "^8.0.0",
+    "source-map-loader": "^0.2.4",
+    "style-loader": "^1.0.0",
+    "ts-jest": "^24.0.2",
+    "webpack": "^4.40.2",
+    "webpack-cli": "^3.3.9",
+    "webpack-dev-server": "^3.8.1"
+  },
+  "jest": {
+    "transform": {
+      "^.+\\.tsx?$": "ts-jest"
+    }
+  }
+}

--- a/examples/benchmark/src/AppProdo.tsx
+++ b/examples/benchmark/src/AppProdo.tsx
@@ -1,0 +1,68 @@
+import * as React from "react";
+import Controls from "./Controls";
+import { shuffle } from "./lib";
+import { model } from "./model";
+
+export const changeN = model.action(
+  ({ state, dispatch }) => async (fraction: number, count: number) => {
+    const idxs = [...Array(state.length)].map((_, i) => i);
+    shuffle(idxs);
+
+    idxs.slice(Math.floor(fraction * state.length)).forEach(idx => {
+      state[idx].value = !state[idx].value;
+    });
+    if (count > 1) {
+      dispatch(changeN)(fraction, count - 1);
+    }
+    await new Promise(res => setTimeout(res, 0));
+  },
+);
+
+export const changeNSync = model.action(
+  ({ state, dispatch }) => (fraction: number, count: number) => {
+    const idxs = [...Array(state.length)].map((_, i) => i);
+    shuffle(idxs);
+
+    idxs.slice(Math.floor(fraction * state.length)).forEach(idx => {
+      state[idx].value = !state[idx].value;
+    });
+    if (count > 1) {
+      dispatch(changeNSync)(fraction, count - 1);
+    }
+  },
+);
+
+const Box = model.connect(({ watch, state }) => ({ idx }: { idx: number }) => {
+  const value = watch(state[idx].value);
+  return <div className={`box ${value ? "on" : "off"}`} />;
+});
+
+const Grid = model.connect(({ watch, state }) => () => {
+  const n = watch(state.length);
+  return (
+    <div>
+      {[...Array(n)].map((_, i) => (
+        <Box key={i} idx={i} />
+      ))}
+    </div>
+  );
+});
+
+const ProdoApp = model.connect(({ dispatch }) => () => (
+  <div>
+    <Controls changeN={dispatch(changeN)} changeNSync={dispatch(changeNSync)} />
+    <Grid />
+  </div>
+));
+
+const { Provider } = model.createStore({
+  initState: [...Array(300)].map(() => ({
+    value: false,
+  })),
+});
+
+export default () => (
+  <Provider>
+    <ProdoApp />
+  </Provider>
+);

--- a/examples/benchmark/src/AppRedux.tsx
+++ b/examples/benchmark/src/AppRedux.tsx
@@ -1,0 +1,126 @@
+import * as React from "react";
+import { connect, Provider } from "react-redux";
+import { applyMiddleware, createStore, Dispatch } from "redux";
+import thunkMiddleware, { ThunkAction } from "redux-thunk";
+import Controls from "./Controls";
+import { shuffle } from "./lib";
+import { State } from "./model";
+
+const initState = [...Array(300)].map(() => ({
+  value: false,
+}));
+
+type Action =
+  | {
+      type: "CHANGE";
+      fraction: number;
+    }
+  | TypedThunkAction<"CHANGE_N">;
+
+const reducer = (state: State = initState, action: Action): State => {
+  switch (action.type) {
+    case "CHANGE":
+      const newState = [...state];
+
+      const idxs = [...Array(state.length)].map((_, i) => i);
+      shuffle(idxs);
+      idxs.slice(Math.floor(action.fraction * state.length)).forEach(idx => {
+        newState[idx].value = !state[idx].value;
+      });
+
+      return newState;
+  }
+  return state;
+};
+
+const change = (fraction: number) => ({
+  type: "CHANGE",
+  fraction,
+});
+
+type TypedThunkAction<T> = ThunkAction<any, any, any, any> & {
+  type: T;
+};
+
+const typedThunk = (
+  thunk: ThunkAction<any, any, any, any>,
+  type: string,
+): Action => {
+  (thunk as any).type = type;
+  return thunk as Action;
+};
+
+const changeN = (fraction: number, count: number): Action => {
+  return typedThunk((dispatch: Dispatch) => {
+    dispatch(change(fraction));
+    if (count > 1) {
+      setTimeout(() => dispatch(changeN(fraction, count - 1)), 0);
+    }
+  }, "CHANGE_N");
+};
+
+const changeNSync = (fraction: number, count: number): Action => {
+  return typedThunk((dispatch: Dispatch) => {
+    dispatch(change(fraction));
+    if (count > 1) {
+      dispatch(changeNSync(fraction, count - 1));
+    }
+  }, "CHANGE_N");
+};
+
+const Box = ({ value }: { value: boolean }) => {
+  return <div className={`box ${value ? "on" : "off"}`} />;
+};
+
+const ConnectedBox = connect((state: State, props: { idx: number }) => ({
+  value: state[props.idx].value,
+}))(Box);
+
+const Grid = ({ n }: { n: number }) => {
+  return (
+    <div>
+      {[...Array(n)].map((_, i) => (
+        <ConnectedBox key={i} idx={i} />
+      ))}
+    </div>
+  );
+};
+
+const ConnectedGrid = connect((state: State) => ({
+  n: state.length,
+}))(Grid);
+
+const App = ({
+  changeN,
+  changeNSync,
+}: {
+  changeN: (fraction: number, count: number) => void;
+  changeNSync: (fraction: number, count: number) => void;
+}) => {
+  return (
+    <div>
+      <Controls changeN={changeN} changeNSync={changeNSync} />
+      <ConnectedGrid />
+    </div>
+  );
+};
+
+const ConnectedApp = connect(
+  () => ({}),
+  dispatch => ({
+    changeN: (fraction: number, count: number) => {
+      dispatch(changeN(fraction, count));
+    },
+    changeNSync: (fraction: number, count: number) => {
+      dispatch(changeNSync(fraction, count));
+    },
+  }),
+)(App);
+
+const store = createStore(reducer, applyMiddleware(thunkMiddleware));
+
+export default () => (
+  <Provider store={store}>
+    <ConnectedApp />
+  </Provider>
+);

--- a/examples/benchmark/src/Controls.tsx
+++ b/examples/benchmark/src/Controls.tsx
@@ -1,0 +1,59 @@
+import * as React from "react";
+
+export default ({
+  changeN,
+  changeNSync,
+}: {
+  changeN: (fraction: number, count: number) => void;
+  changeNSync: (fraction: number, count: number) => void;
+}) => {
+  const [percentage, setPercentage] = React.useState(0.5);
+  const [count, setCount] = React.useState(1);
+  const [sync, setSync] = React.useState(false);
+
+  return (
+    <form>
+      <label>
+        Sync
+        <input
+          type="checkbox"
+          checked={sync}
+          onChange={e => {
+            setSync(e.target.checked);
+          }}
+        />
+      </label>
+      <label>
+        Fraction modified:
+        <input
+          type="number"
+          min="0"
+          max="2"
+          step="0.01"
+          value={percentage}
+          onChange={e => {
+            setPercentage(parseFloat(e.target.value));
+          }}
+        />
+      </label>
+      <label>
+        Repeats:
+        <input
+          type="number"
+          min="0"
+          step="1"
+          value={count}
+          onChange={e => setCount(parseInt(e.target.value, 10))}
+        />
+      </label>
+      <input
+        type="submit"
+        onClick={e => {
+          e.preventDefault();
+          (sync ? changeNSync : changeN)(1 - percentage, count);
+        }}
+        value="change"
+      />
+    </form>
+  );
+};

--- a/examples/benchmark/src/index.html
+++ b/examples/benchmark/src/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="X-UA-Compatible" content="ie=edge" />
+    <title>Clock</title>
+  </head>
+  <body>
+    <div id="root"></div>
+  </body>
+</html>

--- a/examples/benchmark/src/index.scss
+++ b/examples/benchmark/src/index.scss
@@ -1,0 +1,32 @@
+* {
+  box-sizing: border-box;
+}
+
+body {
+  padding: 0;
+  margin: 0;
+}
+
+.box {
+    display: inline-block;
+    width: 20px;
+    height: 20px;
+    background: black;
+    border: 1px solid black;
+    padding: 0;
+    margin: 0;
+}
+
+.box.on {
+    display: inline-block;
+    width: 20px;
+    height: 20px;
+    background: red;
+}
+
+.box.off {
+    display: inline-block;
+    width: 20px;
+    height: 20px;
+    background: blue;
+}

--- a/examples/benchmark/src/index.tsx
+++ b/examples/benchmark/src/index.tsx
@@ -1,0 +1,26 @@
+// tslint:disable:no-console
+
+import * as React from "react";
+import * as ReactDOM from "react-dom";
+import AppProdo from "./AppProdo";
+import AppRedux from "./AppRedux";
+
+import "./index.scss";
+
+const render = () => {
+  ReactDOM.render(
+    <>
+      <AppProdo />
+      <AppRedux />
+    </>,
+    document.getElementById("root"),
+  );
+};
+
+if (module.hot) {
+  module.hot.accept("./AppProdo", () => {
+    render();
+  });
+}
+
+render();

--- a/examples/benchmark/src/lib.ts
+++ b/examples/benchmark/src/lib.ts
@@ -1,0 +1,20 @@
+function randomIntInclusive(min: number, max: number) {
+  // The maximum is exclusive and the minimum is inclusive
+  min = Math.ceil(min);
+  max = Math.floor(max);
+  return Math.floor(Math.random() * (max - min + 1)) + min;
+}
+
+// Knuth-Fischer-Yates
+export function shuffle<T>(data: T[], n?: number) {
+  if (n == null) {
+    n = data.length;
+  }
+
+  for (let i = n - 1; i > 0; i--) {
+    const j = randomIntInclusive(0, i);
+    const tmp = data[i];
+    data[i] = data[j];
+    data[j] = tmp;
+  }
+}

--- a/examples/benchmark/src/model.ts
+++ b/examples/benchmark/src/model.ts
@@ -1,0 +1,9 @@
+import { createModel } from "@prodo/core";
+
+export interface Box {
+  value: boolean;
+}
+
+export type State = Box[];
+
+export const model = createModel<State>();

--- a/examples/benchmark/tsconfig.json
+++ b/examples/benchmark/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "extends": "../../tsconfig.ui.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "lib",
+    "jsx": "react",
+    "target": "es2017",
+    "module": "esnext"
+  },
+  "include": ["src"],
+  "references": [
+    { "path": "../../packages/core" },
+    { "path": "../../packages/babel-plugin" },
+    { "path": "../../packages/stream-plugin" }
+  ]
+}

--- a/examples/benchmark/webpack.config.js
+++ b/examples/benchmark/webpack.config.js
@@ -1,0 +1,46 @@
+const ForkTsCheckerWebpackPlugin = require("fork-ts-checker-webpack-plugin");
+const HtmlWebpackPlugin = require("html-webpack-plugin");
+const path = require("path");
+const APP_PATH = path.resolve(__dirname, "src");
+
+module.exports = {
+  entry: APP_PATH,
+
+  output: {
+    filename: "bundle.js",
+    path: path.resolve(__dirname, "dist"),
+    publicPath: "/",
+  },
+
+  resolve: {
+    extensions: [".ts", ".tsx", ".js", "jsx", ".json"],
+  },
+
+  devtool: "source-map",
+
+  module: {
+    rules: [
+      {
+        test: /\.(ts|js)x?$/,
+        use: ["babel-loader", "source-map-loader"],
+        exclude: /node_modules/,
+      },
+      {
+        test: /\.s?css$/,
+        loader: ["style-loader", "css-loader", "sass-loader"],
+      },
+      {
+        test: /\.(png|jpe?g|svg|ico)$/,
+        loader: "file-loader",
+      },
+    ],
+  },
+
+  plugins: [
+    new HtmlWebpackPlugin({
+      inject: true,
+      template: path.join(APP_PATH, "index.html"),
+    }),
+    new ForkTsCheckerWebpackPlugin(),
+  ],
+};

--- a/packages/core/src/watch.ts
+++ b/packages/core/src/watch.ts
@@ -1,3 +1,4 @@
+import { unstable_batchedUpdates } from "react-dom";
 import logger from "./logger";
 import { Event, Node, Store, WatchTree } from "./types";
 import { splitPath } from "./utils";
@@ -124,12 +125,14 @@ export const submitPatches = (
   logger.info("[update cycle]", comps);
 
   event.rerender = {};
-  Object.keys(comps).forEach(compId => {
-    const { setState, name, newValues, status } = comps[compId];
-    if (!status.unmounted) {
-      event.rerender![comps[compId].name] = true;
-      logger.info(`[upcoming state update] ${name}`, newValues, status);
-      setState(newValues);
-    }
-  });
+  unstable_batchedUpdates(() =>
+    Object.keys(comps).forEach(compId => {
+      const { setState, name, newValues, status } = comps[compId];
+      if (!status.unmounted) {
+        event.rerender![comps[compId].name] = true;
+        logger.info(`[upcoming state update] ${name}`, newValues, status);
+        setState(newValues);
+      }
+    }),
+  );
 };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,6 +2,7 @@
   "files": [],
   "references": [
     { "path": "docs" },
+    { "path": "examples/benchmark" },
     { "path": "examples/chat-app" },
     { "path": "examples/clock" },
     { "path": "examples/kanban" },

--- a/yarn.lock
+++ b/yarn.lock
@@ -2399,15 +2399,6 @@
     "@babel/core" "^7.5.5"
     "@babel/types" "^7.5.5"
 
-"@prodo/core@^0.0.11":
-  version "0.0.11"
-  resolved "https://registry.yarnpkg.com/@prodo/core/-/core-0.0.11.tgz#6f1b6c24b98b0ceba4567a0a6ed581bde44dc997"
-  integrity sha512-gmLsXLT2MKWnrEQ0r5OO++ScNk/WDAooXEKvqw4z8zxKG9RKX5dRN51yzQ/sIZyJ8fyLijf+uduSwMz6/hFayw==
-  dependencies:
-    immer "^3.2.0"
-    react "^16.9.0"
-    react-dom "^16.9.0"
-
 "@protobufjs/aspromise@^1.1.1", "@protobufjs/aspromise@^1.1.2":
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/@protobufjs/aspromise/-/aspromise-1.1.2.tgz#9b8b0cc663d669a7d8f6f5d0893a14d348f30fbf"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2399,6 +2399,15 @@
     "@babel/core" "^7.5.5"
     "@babel/types" "^7.5.5"
 
+"@prodo/core@^0.0.11":
+  version "0.0.11"
+  resolved "https://registry.yarnpkg.com/@prodo/core/-/core-0.0.11.tgz#6f1b6c24b98b0ceba4567a0a6ed581bde44dc997"
+  integrity sha512-gmLsXLT2MKWnrEQ0r5OO++ScNk/WDAooXEKvqw4z8zxKG9RKX5dRN51yzQ/sIZyJ8fyLijf+uduSwMz6/hFayw==
+  dependencies:
+    immer "^3.2.0"
+    react "^16.9.0"
+    react-dom "^16.9.0"
+
 "@protobufjs/aspromise@^1.1.1", "@protobufjs/aspromise@^1.1.2":
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/@protobufjs/aspromise/-/aspromise-1.1.2.tgz#9b8b0cc663d669a7d8f6f5d0893a14d348f30fbf"
@@ -15748,7 +15757,7 @@ react-reconciler@^0.20.0:
     prop-types "^15.6.2"
     scheduler "^0.13.6"
 
-react-redux@^7.0.3:
+react-redux@^7.0.3, react-redux@^7.1.1:
   version "7.1.1"
   resolved "https://registry.yarnpkg.com/react-redux/-/react-redux-7.1.1.tgz#ce6eee1b734a7a76e0788b3309bf78ff6b34fa0a"
   integrity sha512-QsW0vcmVVdNQzEkrgzh2W3Ksvr8cqpAv5FhEk7tNEft+5pp7rXxAudTz3VOPawRkLIepItpkEIyLcN/VVXzjTg==


### PR DESCRIPTION
Previously, react did some work immediately after setState was called.
If a single action triggered state changes in many elements, this caused
updates to be quite slow - up to 1000x vs Redux.

unstable_batchedUpdates is used by Redux to avoid this:
https://react-redux.js.org/api/batch#references.