### PR TITLE
Local plugin nested values

### DIFF
--- a/docs/content/03_plugins/local.md
+++ b/docs/content/03_plugins/local.md
@@ -42,7 +42,7 @@ export interface Config<T> {
 
 `initLocal`
 
-Fallback values to use if an item is not in local storage.
+Values to initialize local storage with.
 
 `localFixture`
 

--- a/docs/content/03_plugins/routing.md
+++ b/docs/content/03_plugins/routing.md
@@ -28,7 +28,7 @@ export const { route /* ... */ } = model.ctx;
 Items added to the `createStore` config.
 
 ```ts
-interface EffectConfig {
+interface RouteConfig {
   route: {
     history: History;
   };

--- a/examples/local-map/package.json
+++ b/examples/local-map/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "@prodo/core": "^0.1.0",
     "@prodo/local": "^0.1.0",
+    "@prodo/logger": "^0.1.0",
     "core-js": "2",
     "pigeon-maps": "^0.13.0",
     "pigeon-marker": "^0.3.4",

--- a/examples/local-map/src/index.tsx
+++ b/examples/local-map/src/index.tsx
@@ -10,7 +10,11 @@ export const initLocal: Partial<Local> = {
   zoom: 12,
 };
 
-const { Provider, store } = model.createStore({ initState: {}, initLocal });
+const { Provider, store } = model.createStore({
+  logger: true,
+  initState: {},
+  initLocal,
+});
 
 const render = () => {
   ReactDOM.render(

--- a/examples/local-map/src/model.ts
+++ b/examples/local-map/src/model.ts
@@ -1,10 +1,13 @@
 import { createModel } from "@prodo/core";
 import localPlugin from "@prodo/local";
+import loggerPlugin from "@prodo/logger";
 
 export interface Local {
   center: [number, number];
   zoom: number;
 }
 
-export const model = createModel<{}>().with(localPlugin<Local>());
+export const model = createModel<{}>()
+  .with(localPlugin<Local>())
+  .with(loggerPlugin);
 export const { state, watch, dispatch, local } = model.ctx;

--- a/examples/local-map/tsconfig.json
+++ b/examples/local-map/tsconfig.json
@@ -7,6 +7,7 @@
   "include": ["src"],
   "references": [
     { "path": "../../packages/core" },
-    { "path": "../../packages/local-plugin" }
+    { "path": "../../packages/local-plugin" },
+    { "path": "../../packages/logger-plugin" }
   ]
 }

--- a/packages/local-plugin/src/index.ts
+++ b/packages/local-plugin/src/index.ts
@@ -3,8 +3,8 @@ import {
   createUniverseWatcher,
   PluginActionCtxFn,
   PluginInitFn,
-  PluginViewCtxFn,
   PluginOnCompleteEventFn,
+  PluginViewCtxFn,
   ProdoPlugin,
 } from "@prodo/core";
 

--- a/packages/local-plugin/tests/index.test.ts
+++ b/packages/local-plugin/tests/index.test.ts
@@ -3,6 +3,7 @@ import localPlugin from "../src";
 
 interface Local {
   count: number;
+  obj: { a: string };
 }
 
 const model = createModel<{}>().with(localPlugin<Local>());
@@ -18,6 +19,18 @@ const setCount = model.action(({ local }) => (value?: number) => {
 
 const increaseCount = model.action(({ local }) => (amount: number) => {
   local.count = (local.count || 0) + amount;
+});
+
+const deleteCount = model.action(({ local }) => () => {
+  delete local.count;
+});
+
+const setObj = model.action(({ local }) => (value: string) => {
+  if (!local.obj) {
+    local.obj = { a: value };
+  } else {
+    local.obj.a = value;
+  }
 });
 
 describe("local plugin", () => {
@@ -49,6 +62,33 @@ describe("local plugin", () => {
 
     const finalUniverse = await store.dispatch(setCount)(100);
     expect(finalUniverse.local.count).toBe(100);
+  });
+
+  it("sets nested local storage value without initLocal", async () => {
+    const { store } = model.createStore({
+      initState: {},
+      localFixture: {},
+    });
+
+    expect(store.universe.local.obj).toBe(undefined);
+    const finalUniverse = await store.dispatch(setObj)("foo");
+    expect(finalUniverse.local.obj!.a).toBe("foo");
+  });
+
+  it("sets nested local storage value without initLocal", async () => {
+    const { store } = model.createStore({
+      initState: {},
+      initLocal: {
+        obj: {
+          a: "foo",
+        },
+      },
+      localFixture: {},
+    });
+
+    expect(store.universe.local.obj!.a).toBe("foo");
+    const finalUniverse = await store.dispatch(setObj)("bar");
+    expect(finalUniverse.local.obj!.a).toBe("bar");
   });
 
   it("updates local storage value with initLocal", async () => {
@@ -87,5 +127,34 @@ describe("local plugin", () => {
     expect(store.universe.local.count).toBe(undefined);
     const finalUniverse = await store.dispatch(increaseCount)(1000);
     expect(finalUniverse.local.count).toBe(1000);
+  });
+
+  it("deletes a local storage value with default", async () => {
+    const { store } = model.createStore({
+      initState: {},
+      initLocal: {
+        count: 1000,
+      },
+      localFixture: {
+        count: 10,
+      },
+    });
+
+    expect(store.universe.local.count).toBe(10);
+    const finalUniverse = await store.dispatch(deleteCount)();
+    expect(finalUniverse.local.count).toBe(1000);
+  });
+
+  it("deletes a local storage value without default", async () => {
+    const { store } = model.createStore({
+      initState: {},
+      localFixture: {
+        count: 10,
+      },
+    });
+
+    expect(store.universe.local.count).toBe(10);
+    const finalUniverse = await store.dispatch(deleteCount)();
+    expect(finalUniverse.local.count).toBe(undefined);
   });
 });


### PR DESCRIPTION
Previously the local plugin would only capture updates made to the top level of `universe.local`. So this would work (update universe and browser local storage)

```ts
local.a = "foo"
```

but this would not

```ts
local.a.b = "foo"
```

This PR makes the second example work. It also supports deleting of local storage items.

Instead of using a proxy to trap `set` calls to `universe.local`, I instead use the plugin `onCompleteEvent` hook to update local storage (if not in fixtures mode) with the new state of the universe and remove any values that were deleted. Some notable changes:

- `config.initLocal` values are store in local storage
- local storage is only read from once in init. This behaves more like local storage middleware for redux