### PR TITLE
Mention styling in github pr list tutorial earlier

### DIFF
--- a/docs/content/05_tutorials/github-prs.md
+++ b/docs/content/05_tutorials/github-prs.md
@@ -99,6 +99,13 @@ export default Header;
 
 The page should update automatically with the new text.
 
+# Styling
+
+_This tutorial is not about CSS. To use the same styles as this tutorial,
+copy [this
+file](https://github.com/prodo-ai/github-prs/blob/master/src/styles.css) to
+`src/styles.css`_
+
 # Specifying the model
 
 In a Prodo app your state is stored in a global store which is accessed by your
@@ -311,11 +318,6 @@ async/await.
 
 We've setup the internals of our app, but still need a way for the user to
 interact with it.
-
-_This tutorial is not about styling. To use the same styles as this tutorial,
-copy [this
-file](https://github.com/prodo-ai/github-prs/blob/master/src/styles.css) to
-`src/styles.css`_
 
 ## Repo search
 


### PR DESCRIPTION
I noticed that the section that menitons styling in the tutorial comes a bit late in the tutorial. This PR moves that section above any visual part of the tutorial.